### PR TITLE
Makes eslint run cleanly for continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
           paths:
             - ./source/node_modules
       - run:
+          name: eslint
+          command: cd source && npm run eslint
+      - run:
           name: test
           command: cd source && npm test
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ source/assets/css/dist/
 source/assets/js/dist/
 source/documentation/
 source/node_modules/
+source/coverage/
 

--- a/source/.eslintignore
+++ b/source/.eslintignore
@@ -1,0 +1,5 @@
+/documentation/**
+/coverage/**
+/assets/js/lib/**
+/assets/js/dist/**
+/assets/js/dropzone.min.js

--- a/source/.eslintrc.js
+++ b/source/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
             "no-undef": "warn",
             "no-unreachable": "warn",
             "no-unused-vars": "warn",
-            "no-useless-escape": "error"
+            "no-useless-escape": "warn"
         }
       }
   ]

--- a/source/.eslintrc.js
+++ b/source/.eslintrc.js
@@ -1,6 +1,3 @@
-const ERROR = 2;
-const WARN = 1;
-
 module.exports = {
     extends: [ "eslint:recommended", "plugin:node/recommended", "plugin:security/recommended"],
     overrides: [
@@ -13,17 +10,12 @@ module.exports = {
           "jest", "security"
         ],
         rules: {
-          "jest/no-disabled-tests": "warn",
-          "jest/no-focused-tests": "error",
-          "jest/no-identical-title": "error",
-          "jest/prefer-to-have-length": "warn",
-          "jest/valid-expect": "error",
-          "node/exports-style": ["error", "module.exports"],
-          "node/prefer-global/buffer": ["error", "always"],
-          "node/prefer-global/console": ["error", "always"],
-          "node/prefer-global/process": ["error", "always"],
-          "node/prefer-global/url-search-params": ["error", "always"],
-          "node/prefer-global/url": ["error", "always"],
+            "no-console": "warn",
+            "no-extra-semi": "warn",
+            "no-undef": "warn",
+            "no-unreachable": "warn",
+            "no-unused-vars": "warn",
+            "no-useless-escape": "error"
         }
       }
   ]

--- a/source/package.json
+++ b/source/package.json
@@ -32,7 +32,8 @@
   },
   "scripts": {
     "test": "jest --colors --coverage",
-    "grunt-dev": "grunt ngAnnotate uglify"
+    "grunt-dev": "grunt ngAnnotate uglify",
+    "eslint": "eslint -c .eslintrc.js ."
   },
   "contributors": [
      "rsmith",


### PR DESCRIPTION
Fixes #31, Fixes #32

We still need to decide if any of the linted items now reported as warnings should really be reported as errors so that the CircleCI build will fail should the linter encounter them. See #41