### PR TITLE
CI build will fail if eslint warnings increase; add eslint jest recommended rules

### DIFF
--- a/source/.eslintrc.js
+++ b/source/.eslintrc.js
@@ -1,22 +1,25 @@
 module.exports = {
-    extends: [ "eslint:recommended", "plugin:node/recommended", "plugin:security/recommended"],
-    overrides: [
-      {
-        files: "**/*.js",
-        env: {
-          jest: true
-        },
-        plugins: [
-          "jest", "security"
-        ],
-        rules: {
-            "no-console": "warn",
-            "no-extra-semi": "warn",
-            "no-undef": "warn",
-            "no-unreachable": "warn",
-            "no-unused-vars": "warn",
-            "no-useless-escape": "warn"
-        }
+  extends: [
+    "eslint:recommended",
+    "plugin:node/recommended",
+    "plugin:security/recommended",
+    "plugin:jest/recommended"
+  ],
+  overrides: [
+    {
+      files: "**/*.js",
+      env: {
+        jest: true
+      },
+      plugins: [ "jest", "security" ],
+      rules: {
+        "no-console": "warn",
+        "no-extra-semi": "warn",
+        "no-undef": "warn",
+        "no-unreachable": "warn",
+        "no-unused-vars": "warn",
+        "no-useless-escape": "warn"
       }
+    }
   ]
 };

--- a/source/package.json
+++ b/source/package.json
@@ -48,7 +48,7 @@
     "test": "jest --coverage --colors",
     "jest-ci": "jest --coverage --colors && cat ./coverage/lcov.info | coveralls",
     "grunt-dev": "grunt ngAnnotate uglify",
-    "eslint": "eslint -c .eslintrc.js ."
+    "eslint": "eslint --color --max-warnings 244 -c .eslintrc.js ."
   },
   "engines": {
     "node": "10.11.x"


### PR DESCRIPTION
~~WIP - let's get #40 merged first and keep aggro down (and have tests pass).~~

- eslint script fails if warnings increase
- .eslintrc: use jest recommended rules and some whitespace tweaking

It would be good for both @jgreben and @jermnelson to review.

We have to start somewhere. This is a pretty bad place to start ... but it is a way to have our CI builds fail if we have an eslint error, or if the warning count goes up.

![image](https://user-images.githubusercontent.com/96775/46390949-58f6ea80-c68f-11e8-9090-e391da99a43e.png)

As we start refactoring and changing code, we'll need to adjust the max-threshold for eslint script in package.json:

![image](https://user-images.githubusercontent.com/96775/46390967-70ce6e80-c68f-11e8-8713-5215231ad1a9.png)
