### PR TITLE
hook up test summary in circleci;  jest coverage not on by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,13 @@ jobs:
       - run:
           name: test
           command: cd source && npm run jest-ci
+          environment:
+            JEST_JUNIT_OUTPUT: "../test-results/jest/jest-results.xml"
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: source/coverage
+          destination: jest-coverage
 
 workflows:
   version: 2

--- a/source/package.json
+++ b/source/package.json
@@ -36,7 +36,6 @@
   },
   "jest": {
     "preset": "jest-puppeteer",
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "assets/js/**/*.js",
       "!assets/js/dist/**",
@@ -47,6 +46,7 @@
   "scripts": {
     "test": "jest --colors",
     "jest-ci": "jest --coverage --colors && cat ./coverage/lcov.info | coveralls",
+    "jest-cov": "jest --coverage --colors",
     "grunt-dev": "grunt ngAnnotate uglify",
     "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js ."
   },

--- a/source/package.json
+++ b/source/package.json
@@ -41,11 +41,15 @@
       "!assets/js/dist/**",
       "!assets/js/lib/**",
       "!assets/js/dropzone.min.js"
+    ],
+    "reporters": [
+      "default",
+      "jest-junit"
     ]
   },
   "scripts": {
     "test": "jest --colors",
-    "jest-ci": "jest --coverage --colors && cat ./coverage/lcov.info | coveralls",
+    "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors",
     "grunt-dev": "grunt ngAnnotate uglify",
     "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js ."


### PR DESCRIPTION
Closes #29

Josh and I noticed that jest coverage was always on when we were working this afternoon;  there is a commit here that fixes it.