### PR TITLE
Add globals to eslintrc to suppress no-undef warnings

### DIFF
--- a/source/.eslintrc.js
+++ b/source/.eslintrc.js
@@ -19,6 +19,10 @@ module.exports = {
         "no-unreachable": "warn",
         "no-unused-vars": "warn",
         "no-useless-escape": "warn"
+      },
+      "globals": {
+          "page": true,
+          "angular": true
       }
     }
   ]

--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -1,5 +1,3 @@
-/*global page*/
-
 describe('Sinopia Profile Editor Homepage', () => {
 
     beforeAll(async () => {

--- a/source/__tests__/locApp.test.js
+++ b/source/__tests__/locApp.test.js
@@ -1,5 +1,3 @@
-/*global page*/
-
 describe('Sinopia Profile Editor Homepage', () => {
 
   beforeAll(async () => {

--- a/source/package.json
+++ b/source/package.json
@@ -45,10 +45,10 @@
     ]
   },
   "scripts": {
-    "test": "jest --coverage --colors",
+    "test": "jest --colors",
     "jest-ci": "jest --coverage --colors && cat ./coverage/lcov.info | coveralls",
     "grunt-dev": "grunt ngAnnotate uglify",
-    "eslint": "eslint --color --max-warnings 244 -c .eslintrc.js ."
+    "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js ."
   },
   "engines": {
     "node": "10.11.x"


### PR DESCRIPTION
`angular` var snd jest's `page` var should be defined as global vars as far as eslint is concerned.

Fixes #58