### PR TITLE
working docker image with node base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
           name: eslint
           command: npm run eslint
       - run:
-          name: gruntjs
+          name: build with grunt
           command: npm run grunt-dev
       - run:
-          name: jest
+          name: test with jest and puppeteer
           command: npm run jest-ci
           environment:
             JEST_JUNIT_OUTPUT: "test-results/jest/jest-results.xml"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.circleci
+.git
+coverage
+documentation
+node_modules
+npm-debug.log
+static-analysis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM php:7.2-apache
+FROM node:10.11
 
-ENV HTML /var/www/html
-COPY source $HTML
+ENV HTML /opt/sinopia_profile_editor/
+WORKDIR $HTML
 
-RUN apt-get update && \
-    apt-get install -y gnupg curl && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get update && \
-    apt-get install -y nodejs
+COPY package*.json $HTML
+# FIXME: should this be npm install with --production flag?
+RUN cd $HTML && npm install
 
-RUN cd $HTML && \
-    npm install && \
-    npm install angular-local-storage && \
-    npm install -g grunt-cli && \
-    grunt
+# FIXME: do we want to run grunt locally and copy only dist/ to docker image?
+COPY Gruntfile.js $HTML
+COPY source/ $HTML/source/
+# FIXME: grunt-cli could be an npm devDependency ?
+RUN cd $HTML && npm install -g grunt-cli && npm run grunt-dev
+
+COPY dist/ $HTML
+COPY server.js $HTML
+
+# docker daemon maps app's port
+EXPOSE 8000
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN cd $HTML && npm install
 # FIXME: do we want to run grunt locally and copy only dist/ to docker image?
 COPY Gruntfile.js $HTML
 COPY source/ $HTML/source/
-# FIXME: grunt-cli could be an npm devDependency ?
-RUN cd $HTML && npm install -g grunt-cli && npm run grunt-dev
+RUN cd $HTML && npm run grunt-dev
 
 COPY dist/ $HTML
 COPY server.js $HTML

--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ Technical documentation specific to the Sinopia Profile Editor
 
 ### Installation Instructions
 1.  install node.js
-2.	Run `npm init`, and follow the instructions that appear.
+2.  Run `npm init`, and follow the instructions that appear.
 3.  Get latest npm: `npm install -g npm@latest`
-4.	Run `npm install`. This installs everything needed for Grunt to run successfully.
-5.  Install grunt command line interface `npm install grunt-cli`
-6.  Run `grunt` to build the code and jsdocs and ngdocs.
+4.  Run `npm install`. This installs everything needed for the build to run successfully.
+5.  Run `grunt` to build the code and jsdocs and ngdocs.
 
 ## Running the code
 
-Follow installation instructions, then run `node server.js`.  This will start up the profile editor at http://localhost:8000
+Follow installation instructions, then run `node server.js` or `npm start`.  This will start up the profile editor at http://localhost:8000
 
 ## Developers
 
-The javascript code uses the angular framework https://angular.io/.  It uses grunt as a build tool.
+The javascript code uses the AngularJS framework https://angular.io/.  It uses grunt as a build tool.
 
 ### grunt-dev
 

--- a/package.json
+++ b/package.json
@@ -48,12 +48,13 @@
     ]
   },
   "scripts": {
-    "test": "jest --colors",
+    "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js",
+    "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
+    "grunt-dev": "grunt ngAnnotate uglify",
+    "start": "node server.js",
     "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors",
-    "grunt-dev": "grunt ngAnnotate uglify cssmin",
-    "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
-    "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js"
+    "test": "jest --colors"
   },
   "engines": {
     "node": "10.11.x"

--- a/server.js
+++ b/server.js
@@ -1,4 +1,7 @@
-var port = 8000;
+
+const port = 8000;
+// const host = '127.0.0.1'
+
 var express = require('express');
 
 var app = express();
@@ -6,7 +9,12 @@ var app = express();
 app.use(express.static('dist'));
 app.use(express.static('source'));
 app.use(express.static('node_modules'));
+app.all("/verso*", function (req, res) {
+  res.send("Verso not enabled")
+})
+// app.listen(port, host);
 app.listen(port);
 
-console.log('Sinopia Profile Editor running on ' + port);
+// console.log(`Sinopia Profile Editor running on http://${host}:${port}`);
+console.log(`Sinopia Profile Editor running on localhost:${port}`);
 console.log('Press Ctrl + C to stop.');


### PR DESCRIPTION
five unrelated commits here, so possibly review by commit?
- docker image built from node:10.11 and I confirmed that running the container locally with `docker run -p 8000:8000 ld4p/sinopia_profile_editor:0.0.1` resulted in a working app at port 8000.
- make grunt-cli a devDependency
- package.json: alphabetize scripts by name
- server.js: in the course of trying to figure out the docker image, I ended up tweaking this file slightly.  Push back is welcome.
- .circleci/config.yml: found 2 more steps with undescriptive names

Note to @jermnelson: I don't think you need to explicitly declare the npm start script in package.json -- I think if the file is named server.js in the top directory, it's npm magic.  Kind of like npm test.  https://docs.npmjs.com/cli/start

Connects to #60, #22