### PR TITLE
Test profile export

### DIFF
--- a/source/__tests__/integration/export-profile.test.js
+++ b/source/__tests__/integration/export-profile.test.js
@@ -1,0 +1,31 @@
+const path = require('path')
+
+describe('Sinopia Profile Editor exports a loaded Profile', () => {
+
+  beforeAll(async () => {
+    await page.goto('http://127.0.0.1:8000/#/profile/create')
+  })
+
+  it('clicks Verbose Export and displays an error with missing profile form data', async () => {
+     await expect(page).toClick('a', { text: 'Verbose Export'})
+     const alert_box_header = await page.$eval('#alertBox > div > div > div.modal-header > h3', e => e.textContent)
+     await expect(alert_box_header).toMatch(/Error\!/)
+ })
+
+  describe('Exporting an existing profile', () => {
+
+    beforeAll(async () => {
+      await expect(page).toClick('a', { text: 'Import'})
+      const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item.json')
+      await expect(page).toUploadFile(
+        'input[type="file"]',
+        bf_item_location,
+      )
+    })
+
+    it('clicks the Verbose Button and downloads the loaded Profile', async () => {
+      await page.waitFor(1000)
+      await expect(page).toClick('a', { text: 'Verbose Export'})
+    })
+  })
+})

--- a/source/__tests__/integration/export-profile.test.js
+++ b/source/__tests__/integration/export-profile.test.js
@@ -6,10 +6,10 @@ describe('Sinopia Profile Editor exports a loaded Profile', () => {
     await page.goto('http://127.0.0.1:8000/#/profile/create')
   })
 
-  it('clicks Verbose Export and displays an error with missing profile form data', async () => {
+  it('error displayed when exporting profile form data', async () => {
      await expect(page).toClick('a', { text: 'Verbose Export'})
      const alert_box_header = await page.$eval('#alertBox > div > div > div.modal-header > h3', e => e.textContent)
-     await expect(alert_box_header).toMatch(/Error\!/)
+     await expect(alert_box_header).toMatch(/Error!/)
  })
 
   describe('Exporting an existing profile', () => {
@@ -23,9 +23,10 @@ describe('Sinopia Profile Editor exports a loaded Profile', () => {
       )
     })
 
-    it('clicks the Verbose Button and downloads the loaded Profile', async () => {
+    it('saves a non-empty Profile', async () => {
       await page.waitFor(1000)
       await expect(page).toClick('a', { text: 'Verbose Export'})
+      // TODO: test that profile written to file system (see #77)
     })
   })
 })

--- a/source/__tests__/integration/profile-create.test.js
+++ b/source/__tests__/integration/profile-create.test.js
@@ -12,11 +12,11 @@ describe('Sinopia Profile Editor imports a Profile', () => {
       await expect(page).toClick('a', { text: 'Import'})
     })
 
-    it('displays Import Data dialog after Import button is clicked', async () => {
+    it('displays Import Data dialog', async () => {
       await expect(page).toMatch(/Import Data/)
     })
 
-    it('uploads a local BIBFRAME 2.0 Item Profile', async () => {
+    it('uploads a local Item Profile and checks to see if it is loaded', async () => {
       const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item.json')
 
       await expect(page).toUploadFile(


### PR DESCRIPTION
This test successfully imports an existing profile and exports to the local machine.  Also tests for error when the Verbose Export is clicked without a valid Profile. Improved description and syntax in import profile test as suggested in PR [#64](https://github.com/LD4P/sinopia_profile_editor/pull/64).

Moved "problem of trying to figure out the best way to confirm the file was downloaded to a separate ticket."

Related to #77 
Fixes #52 