### PR TITLE
use scss-lint for CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ documentation/jsdoc
 documentation/ngdocs
 junit.xml
 node_modules/
+scss-lint-report.xml
 static-analysis

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,13 @@
+scss_files: source/assets/css/**/*.css
+
+exclude:
+  - coverage/*
+  - dist/*
+  - documentation/*
+  - node_modules/*
+  - source/assets/css/jquery*.css
+  - source/assets/css/bootstrap/**
+  - source/assets/css/font-awesome/**
+  - static-analysis/*
+
+#linters:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -10,4 +10,89 @@ exclude:
   - source/assets/css/font-awesome/**
   - static-analysis/*
 
-#linters:
+# $ scss-lint --format=Stats -c .scss-lint.yml --color source/assets/css/dropzone.css  source/assets/css/explorer8.css  source/assets/css/explorer9.css source/assets/css/profileTemplate.css
+# 281  Indentation                    (across 4 files)
+#  56  SelectorFormat                 (across 3 files)
+#  44  IdSelector                     (across 3 files)
+#  44  QualifyingElement              (across 2 files)
+#  42  ColorVariable                  (across 3 files)
+#  40  PropertySortOrder              (across 3 files)
+#  32  ImportantRule                  (across 3 files)
+#  29  MergeableSelector              (across 3 files)
+#  17  SingleLinePerSelector          (across 3 files)
+#  17  HexNotation                    (across 3 files)
+#  16  TrailingWhitespace             (across 3 files)
+#  15  ZeroUnit                       (across 2 files)
+#  13  ColorKeyword                   (across 1 files)
+#  10  Comment                        (across 3 files)
+#   8  LeadingZero                    (across 1 files)
+#   8  SpaceBeforeBrace               (across 2 files)
+#   6  SpaceAfterComma                (across 1 files)
+#   6  EmptyLineBetweenBlocks         (across 1 files)
+#   5  BangFormat                     (across 1 files)
+#   4  FinalNewline                   (across 4 files)
+#   2  UnnecessaryMantissa            (across 1 files)
+#   2  SelectorDepth                  (across 2 files)
+#   1  SpaceAfterPropertyColon        (across 1 files)
+#   1  VendorPrefix                   (across 1 files)
+#   1  Shorthand                      (across 1 files)
+#   1  TrailingSemicolon              (across 1 files)
+# ---  -----------------------        ----------------
+# 701  total                          (across 4 files)
+
+# Below was generated with
+# $ scss-lint --format=Config -c .scss-lint.yml --color source/assets/css/dropzone.css  source/assets/css/explorer8.css  source/assets/css/explorer9.css source/assets/css/profileTemplate.css
+---
+linters:
+  BangFormat:
+    enabled: false
+  ColorKeyword:
+    enabled: false
+  ColorVariable:
+    enabled: false
+  Comment:
+    enabled: false
+  EmptyLineBetweenBlocks:
+    enabled: false
+  FinalNewline:
+    enabled: false
+  HexNotation:
+    enabled: false
+  IdSelector:
+    enabled: false
+  ImportantRule:
+    enabled: false
+  Indentation:
+    enabled: false
+  LeadingZero:
+    enabled: false
+  MergeableSelector:
+    enabled: false
+  PropertySortOrder:
+    enabled: false
+  QualifyingElement:
+    enabled: false
+  SelectorDepth:
+    enabled: false
+  SelectorFormat:
+    enabled: false
+  Shorthand:
+    enabled: false
+  SingleLinePerSelector:
+    enabled: false
+  SpaceAfterComma:
+    enabled: false
+  SpaceAfterPropertyColon:
+    enabled: false
+  SpaceBeforeBrace:
+    enabled: false
+  TrailingSemicolon:
+    enabled: false
+  TrailingWhitespace:
+    enabled: false
+  UnnecessaryMantissa:
+    enabled: false
+  VendorPrefix:
+    enabled: false
+  ZeroUnit:
+    enabled: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,6 +101,19 @@ module.exports = function(grunt) {
 		},
     eslint: {
         target: ['source/assets/js/modules/**/*.js']
+    },
+    scsslint: {
+      allFiles: [
+        'source/assets/css/**/*.css'
+      ],
+      options: {
+        // bundleExec: true,
+        colorizeOutput: true,
+        config: '.scss-lint.yml',
+        failOnWarning: true,
+        maxBuffer: 512000,
+        reporterOutput: 'scss-lint-report.xml',
+      }
     }
 	});
 
@@ -110,6 +123,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-ngdocs');
 	grunt.loadNpmTasks('grunt-jsdoc');
 	grunt.loadNpmTasks('grunt-eslint');
+	grunt.loadNpmTasks('grunt-scss-lint');
 
 	grunt.registerTask('default', ['ngAnnotate', 'uglify', 'cssmin', 'ngdocs', 'jsdoc']);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4295,6 +4295,18 @@
         "upath": "~0.2.0"
       }
     },
+    "grunt-scss-lint": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-scss-lint/-/grunt-scss-lint-0.5.0.tgz",
+      "integrity": "sha1-m5gj+AdPM0ZQ/4MfVRoez1sIohU=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "lodash": "^4.12.0",
+        "which": "^1.2.8",
+        "xmlbuilder": "^8.2.2"
+      }
+    },
     "gzip-size": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
@@ -9485,6 +9497,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
       "dev": true
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-jsdoc": "^2.2.1",
     "grunt-ng-annotate": "^3.0.0",
     "grunt-ngdocs": "^0.2.11",
+    "grunt-scss-lint": "^0.5.0",
     "jest": "^23.6.0",
     "jest-junit": "^5.2.0",
     "jest-puppeteer": "^3.4.0",


### PR DESCRIPTION
Connects to #76

As with LD4P/sinopia_editor#61:

Note:  there are other CSS linters out there -- I went with scss-lint because it was recommended by Jack and Camille.

Notes:
- requires scss-lint gem to be installed to run, which requires ruby.
    - due to this, didn't try to hook up CI; to run locally install the gem first.
- I didn't explore all configuration options;  I picked something that would run against our two existing css files;  there may be better choices.
- separate commit showing which rules we violate right now, and how to autogen that list.  I believe all of those are warnings, not errors.

If we merge this:
Do we need a ticket for "decide which CSS rules we care about"?
Do we need a ticket to add info about how to run this to the README?