### PR TITLE
Build and Register a Docker Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,20 +10,37 @@ defaults: &defaults
 
 version: 2
 jobs:
+  # Maintains cache of 2 sets of node_modules: production and CI
+  dependencies:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-prod-{{ checksum "package.json" }}
+      - run: npm install --only=production
+      - save_cache:
+          key: dependency-cache-prod-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - restore_cache:
+          key: dependency-cache-ci-{{ checksum "package.json" }}
+      - run: npm install # including CI/Test dependencies
+      - save_cache:
+          key: dependency-cache-ci-{{ checksum "package.json" }}
+          paths:
+            - node_modules
   build:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - node_modules
+          key: dependency-cache-ci-{{ checksum "package.json" }}
       - run: npm run eslint
       - run: sudo npm install -g grunt
       - run: grunt ngAnnotate uglify cssmin
+      - persist_to_workspace:
+          root: dist
+          paths: assets
       - run:
           name: test with jest and puppeteer
           command: npm run jest-ci
@@ -44,6 +61,10 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - restore_cache: # gives us back matching node_modules
+          key: dependency-cache-prod-{{ checksum "package.json" }}
+      - attach_workspace:
+          at: dist
       - run:
           name: Build & Register Image
           command: |
@@ -55,7 +76,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - dependencies
+      - build:
+          requires:
+            - dependencies
       - register_image:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,11 @@ jobs:
           name: eslint
           command: npm run eslint
       - run:
+          name: install grunt
+          command: sudo npm install -g grunt
+      - run:
           name: build with grunt
-          command: npm run grunt-dev
+          command: grunt
       - run:
           name: test with jest and puppeteer
           command: npm run jest-ci
@@ -47,8 +50,25 @@ jobs:
           path: static-analysis
           destination: static-analysis
 
+  register_image:
+    docker:
+      - image: circleci/node:10.11-browsers
+    working_directory: ~/sinopia_profile_editor
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build & Register Image
+          command: |
+            docker build -t ld4p/sinopia_profile_editor:latest .
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker push ld4p/sinopia_profile_editor:latest
+
 workflows:
   version: 2
   build:
     jobs:
       - build
+      - register_image:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,27 +14,16 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Install latest npm
-          command: 'sudo npm install -g npm@latest'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: npm install
-          command: npm install
+      - run: npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - run:
-          name: eslint
-          command: npm run eslint
-      - run:
-          name: install grunt
-          command: sudo npm install -g grunt
-      - run:
-          name: build with grunt
-          command: grunt ngAnnotate uglify cssmin
+      - run: npm run eslint
+      - run: sudo npm install -g grunt
+      - run: grunt ngAnnotate uglify cssmin
       - run:
           name: test with jest and puppeteer
           command: npm run jest-ci
@@ -45,9 +34,7 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: jest-coverage
-      - run:
-          name: static analysis
-          command: npm run analysis
+      - run: npm run analysis
       - store_artifacts:
           path: static-analysis
           destination: static-analysis

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,16 @@
 #
 # Check https://hub.docker.com/r/circleci/node/ for more details
 #
+
+defaults: &defaults
+  docker:
+    - image: circleci/node:10.11-browsers
+  working_directory: ~/sinopia_profile_editor
+
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/node:10.11-browsers
-
-    working_directory: ~/sinopia_profile_editor
-
+    <<: *defaults
     steps:
       - checkout
       - run:
@@ -32,7 +34,7 @@ jobs:
           command: sudo npm install -g grunt
       - run:
           name: build with grunt
-          command: grunt
+          command: grunt ngAnnotate uglify cssmin
       - run:
           name: test with jest and puppeteer
           command: npm run jest-ci
@@ -51,9 +53,7 @@ jobs:
           destination: static-analysis
 
   register_image:
-    docker:
-      - image: circleci/node:10.11-browsers
-    working_directory: ~/sinopia_profile_editor
+    <<: *defaults
     steps:
       - checkout
       - setup_remote_docker

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,5 @@
 .git
 coverage
 documentation
-node_modules
 npm-debug.log
 static-analysis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
 FROM node:10.11
+WORKDIR /opt/sinopia_profile_editor/
 
-ENV HTML /opt/sinopia_profile_editor/
-WORKDIR $HTML
+# both package.json AND package-lock.json
+COPY package*.json ./
 
-COPY package*.json $HTML
-# FIXME: should this be npm install with --production flag?
-RUN cd $HTML && npm install
+RUN npm install --production
 
-# FIXME: do we want to run grunt locally and copy only dist/ to docker image?
-COPY Gruntfile.js $HTML
-COPY source/ $HTML/source/
-RUN cd $HTML && npm run grunt-dev
-
-COPY dist/ $HTML
-COPY server.js $HTML
+# Everything that isn't in .dockerignore ships
+COPY . .
 
 # docker daemon maps app's port
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM node:10.11
 WORKDIR /opt/sinopia_profile_editor/
 
-# both package.json AND package-lock.json
-COPY package*.json ./
-
-RUN npm install --production
-
 # Everything that isn't in .dockerignore ships
 COPY . .
 


### PR DESCRIPTION
The `Dockerfile` is now nice and textbook simple.  As another benefit, the production dependencies are now the only ones copied into the container, and they are cached on the hash of the `package.json`, instead of a separate execution and resolution of `npm install` only visible inside the container.

You can confirm you like the docker container being created with:
```
docker pull ld4p/sinopia_profile_editor
docker run -p 8000:8000 ld4p/sinopia_profile_editor:latest
```

After this, we can move on to the AWS side of auto-deploying the built container.

Fixes #60 