### PR TITLE
refactor homePage and profileCreate integration tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
       },
       "globals": {
           "page": true,
+          "window": true,
           "angular": true
       }
     }

--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -2,34 +2,56 @@ describe('Sinopia Profile Editor Homepage', () => {
 
   beforeAll(async () => {
     await page.goto('http://127.0.0.1:8000')
-    // await page.waitFor(1000)
   })
 
-  it('displays "Profiles on Server" text on page', async () => {
-    await expect(page).toMatch('Create a new Profile or Import one from your files')
+  it('redirects to profile/sinopia', async () => {
+    const new_url = await page.evaluate(() => window.location.href)
+    expect(new_url).toBe('http://127.0.0.1:8000/#/profile/sinopia')
   })
 
-  it('has the header links', async () => {
-    await expect(page).toMatch('a', { text: 'Biblographic Editor' })
-    await expect(page).toMatch('a', { text: 'Help and Resources' })
+  describe('header', () => {
+    it('image', async() => {
+      await expect_sel_to_exist('div.sinopia-headertext > img[src="assets/images/sinopia_profile_headertext.png"]')
+    });
+    it('links', async () => {
+      await expect_value_in_selector_textContent('div.sinopia-headerlinks > a:nth-child(1)', 'Bibliographic Editor')
+      await expect_value_in_selector_textContent('div.sinopia-headerlinks > a:nth-child(2)', 'Help and Resources')
+    })
   })
 
-  it('has a link to the create new profile page', async () => {
-    const link = await page.$eval('.new-profile', e => e.getAttribute('href'))
-    expect(link).toMatch(/#\/profile\/create/)
+  it('text on page', async () => {
+    await expect_regex_in_selector_textContent('h3.new-profile-header', /\s*Create a new Profile or Import one from your files\s*$/)
   })
 
-  it('has the import profile button', async () => {
-    await expect(page).toMatch('Import')
+  it('link to create new profile page', async () => {
+    await expect_regex_in_selector_textContent('a.new-profile[href="#/profile/create/"]', /\s*Create new Profile\s*/)
   })
 
-  it('has the footer info', async () => {
+  it('Import button redirects to profile/create/true', async () => {
+    await expect(page).toClick('a.btn.import-export[ng-click="showImport()"]')
+    const new_url = await page.evaluate(() => window.location.href)
+    expect(new_url).toBe('http://127.0.0.1:8000/#/profile/create/true')
+  })
+
+  it('footer', async () => {
     await expect(page).toMatch('funded by the Andrew W. Mellon Foundation')
-    await expect(page).toMatch('a', { text: 'Linked Data for Production 2 (LD4P2)' })
+    await expect_value_in_selector_textContent('div.sinopia-footer > a', 'Linked Data for Production 2 (LD4P2)')
   })
 
   it('loads our angular app', async () => {
-    const app = await page.$eval('html', e => e.getAttribute('ng-app'))
-    expect(app).toMatch(/locApp/)
+    expect_sel_to_exist('html[ng-app="locApp"]')
   })
-});
+})
+
+async function expect_sel_to_exist(sel) {
+  const sel_text = !!(await page.$(sel))
+  expect(sel_text).toEqual(true)
+}
+async function expect_regex_in_selector_textContent(sel, regex) {
+  const sel_text = await page.$eval(sel, e => e.textContent)
+  expect(sel_text).toMatch(regex)
+}
+async function expect_value_in_selector_textContent(sel, value) {
+  const sel_text = await page.$eval(sel, e => e.textContent)
+  expect(sel_text).toBe(value)
+}


### PR DESCRIPTION
@jermnelson and @jgreben and I discussed this earlier today.  The basic idea is to get the integration tests grouped better.

I also decided to "improve" the tests in these ways:
- use more specific selectors, when possible, without getting too brittle
- use helper functions to make tests read more cleanly (ld4p/sinopia_editor#75 is about how to avoid redeclaring these in every test file)

added some tests:
* homePage
    - redirect url test
    - header img test
    - import button redirects to expected route

* profileCreate
    - add tests for /profile/create (without /true, so no modal)
    - moved import button tests to homePage
    - changed upload dialog test to be more targeted to simply proving the profile we uploaded showed up (rather than proving all the resource templates were loaded, with vague selectors)