### PR TITLE
spoof verso calls to get profiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
           name: build with grunt
           command: npm run grunt-dev
       - run:
+          name: get profiles static data via git submodule
+          command: npm run git-submodule
+      - run:
           name: test with jest and puppeteer
           command: npm run jest-ci
           environment:

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ coverage
 dist
 documentation/jsdoc
 documentation/ngdocs
+sample_data_from_verso
 source/assets/js/lib/**
 source/assets/js/dropzone.min.js
 static-analysis

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,12 @@ module.exports = {
           "window": true,
           "angular": true
       }
+    },
+    {
+      files: ["source/__tests__/**/*.js", "server.js"],
+      rules: {
+        "no-console": "off"
+      }
     }
   ]
 };

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sample_data_from_verso"]
+	path = sample_data_from_verso
+	url = git@github.com:lcnetdev/verso.git

--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
   },
   "scripts": {
     "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js",
-    "dev-test": "npm install && npm run grunt-dev && jest --colors",
+    "dev-test": "npm install && npm run grunt-dev && npm run git-submodule && jest --colors",
     "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
+    "git-submodule": "git submodule init && git submodule update",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
     "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js",
     "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
-    "start": "node server.js",
     "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors",
     "test": "jest --colors"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js",
+    "dev-test": "npm install && npm run grunt-dev && jest --colors",
     "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
     "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",

--- a/server.js
+++ b/server.js
@@ -3,14 +3,19 @@ const port = 8000;
 // const host = '127.0.0.1'
 
 var express = require('express');
-
 var app = express();
 
 app.use(express.static('dist'));
 app.use(express.static('source'));
 app.use(express.static('node_modules'));
+
+const versoSpoof = require('./source/versoSpoof.js')
 app.all("/verso*", function (req, res) {
-  res.send("Verso not enabled")
+  if (req.query.filter.where.configType === 'profile') {
+    res.json(versoSpoof.profiles)
+  } else {
+    res.send("Verso not enabled")
+  }
 })
 // app.listen(port, host);
 app.listen(port);

--- a/source/__tests__/integration/create-property.test.js
+++ b/source/__tests__/integration/create-property.test.js
@@ -1,0 +1,55 @@
+describe('Create properties in resource', () => {
+  beforeEach(async () => {
+    await page.goto('http://127.0.0.1:8000/#/profile/create')
+    page
+      .waitForSelector('button#addResource')
+      .then(async () => await page.click('button#addResource'))
+      .catch(error => console.log(`testing promise error for addResource link: ${error}`))
+    page
+      .waitForSelector('a.propertyLink')
+      .then(async () => await page.click('a.propertyLink'))
+      .catch(error => console.log(`testing promise error for property link: ${error}`))
+    await page.waitForSelector('span[href="#property_1"]')
+  })
+
+  // it('gives error if exported without property URI', () => {
+  //   // TODO: write this test
+  // })
+  // it('can be exported with property URI', () => {
+  //   // TODO: write this test
+  //   // it shouldn't throw an error
+  // })
+
+  describe('adding a template', () => {
+    let template_select_sel = 'select#templateSelect_1_0'
+    beforeEach(async () => {
+      page
+        .waitForSelector('a#addTemplate')
+        .then(async () => await page.click('a#addTemplate'))
+        .catch(error => console.log(`testing promise error for add template link: ${error}`))
+      await page.waitForSelector(template_select_sel)
+    })
+
+    it('loads profiles from versoSpoof', async () => {
+      const profile_count = await page.$eval(template_select_sel, e => e.length)
+      expect(profile_count).toBe(235)
+    })
+
+    it('can select a template', async () => {
+      // NOTE: the html doesn't always shows the first option selected, though the browser
+      //  shows the right thing.  So here we cheat and use indirect checking of attributes
+      //  to show a template can be selected
+      await expect_sel_to_exist(`${template_select_sel}.ng-pristine`)
+      await expect_sel_to_exist(`${template_select_sel} > option[selected="selected"][value="?"]`)
+      const value_selected = 'profile:bf2:Form'
+      await page.select(template_select_sel, value_selected)
+      await expect_sel_to_exist(`${template_select_sel}.ng-dirty`)
+      await expect_sel_to_exist(`${template_select_sel} > option[selected="selected"][value^="profile:bf2"]`)
+    })
+  })
+})
+
+async function expect_sel_to_exist(sel) {
+  const sel_text = !!(await page.$(sel))
+  expect(sel_text).toEqual(true)
+}

--- a/source/__tests__/versoSpoof.test.js
+++ b/source/__tests__/versoSpoof.test.js
@@ -1,0 +1,18 @@
+describe('profiles from spoofed verso', () => {
+  let verso_spoof  = require('../../source/versoSpoof.js')
+
+  it('array of length 30', () => {
+    expect(verso_spoof.profiles).toHaveLength(30)
+  })
+  it('profile has id', () => {
+    expect(verso_spoof.profiles[0]['id']).toBe('profile:bf2:AdminMetadata')
+  })
+  it('profile has name', () => {
+    expect(verso_spoof.profiles[0]['name']).toBe('Metadata for BIBFRAME Resources')
+  })
+  it('profile has type', () => {
+    verso_spoof.profiles.forEach(p => {
+      expect(p['configType']).toBe('profile')
+    })
+  })
+});

--- a/source/versoSpoof.js
+++ b/source/versoSpoof.js
@@ -1,0 +1,23 @@
+// spoof verso calls to get profiles, vocabularies and ontologies
+const path = require('path')
+const fs = require('fs')
+const profilesDirPath = path.join(__dirname, '..', 'sample_data_from_verso', 'data', 'profiles')
+
+var profiles = []
+loadProfiles()
+module.exports.profiles = profiles
+
+function loadProfiles () {
+  if (profiles.length == 0) {
+    fs.readdirSync(profilesDirPath).forEach(file => {
+      const fileJson = require(path.join(profilesDirPath, file))
+      profiles.push(
+        { id: fileJson['Profile']['id'],
+          name: fileJson['Profile']['description'],
+          configType: 'profile',
+          json: fileJson
+        }
+      )
+    })
+  }
+}


### PR DESCRIPTION
Aside from spoofing verso calls to retrieve profiles, this PR:
- required a git submodule to do the spoofing, so added a step to circleci build and added some npm scripts
- removed `npm start` script as it is provided by default
- turned off no-console rule for all test classes and for server.js

Connects to #102