### PR TITLE
Only build/post the "latest" container from master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,3 +86,7 @@ workflows:
       - register_image:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
We *may* want Docker containers for every dev branch (probably not). But the purpose of "latest" here is to facilitate CD, so we definitely do not want that from every commit on every dev branch.

This was not included in my initial PR because of the catch 22 (I wanted to have the PR build the container to be reviewed, but if I filtered, it would not build until after reviewed).

Note that this filter has its effect because this PR did not trigger `register_image`