### PR TITLE
Removed angular template code that displayed property name for deletion

### DIFF
--- a/source/html/propertyTemplate.html
+++ b/source/html/propertyTemplate.html
@@ -9,22 +9,22 @@
             </span>
             <i id="error" class="fa fa-exclamation red" ng-show="propertyForm.$invalid || !propertyValid(propertyTemplate)"></i>
         </span>
-        
+
         <a id="propertyChoose" class="pull-right" data-toggle="modal" href="#chooseResource" ng-click="updateChosenProperty(propertyTemplate);" onclick="event.returnValue = false; return false;">
             <i class="fa fa-bars"></i>
             {{!propertyTemplate.propertyURI ? "Select Property" : "Change Property" }}
         </a>
-        
+
         <a id="deleteIcon" href="#" ng-click="verifyDelete(deleteProperty)" class="pull-right" onclick="event.returnValue = false; return false;">
             <i class="fa fa-trash-o"></i>
-            Delete {{propertyTemplate.propertyLabel || "Property Template"}}
+            Delete 
         </a>
     </h4>
 </div>
 
 <div ng-controller="propertyTemplateController" id="property_{{item}}" class="panel-collapse collapse">
     <div class="panel-body">
-        
+
         <table>
             <tbody>
                 <tr>
@@ -117,6 +117,6 @@
             </div>
             <button class="btn btn-secondary" ng-click="addPropertyResource();" onclick="return false;">Add Resource</button>
         </div>
-        
+
     </div>
 </div>


### PR DESCRIPTION
In each of the property accordians, the "Delete {property-name}" would often loop around and display on the next line, confusing the user and sometimes making the Delete link inaccessible. As per the ticket, just removed the property name so that for all of the properties in a Resource Template, the head now just has a trash icon and the work **Delete**.

Fixes #110