### PR TITLE
Adds tests for exporting and validating an edited profile

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,9 +21,16 @@ module.exports = {
         "no-useless-escape": "warn"
       },
       "globals": {
+          "angular": true,
+          "document": true,
           "page": true,
-          "window": true,
-          "angular": true
+          "window": true
+      }
+    },
+    {
+      files: ["source/__tests__/**/*.js", "server.js"],
+      rules: {
+        "no-console": "off"
       }
     },
     {

--- a/source/__tests__/integration/empty-profile-export.test.js
+++ b/source/__tests__/integration/empty-profile-export.test.js
@@ -1,0 +1,21 @@
+describe('Sinopia Profile Editor does not export an invalid Profile', () => {
+
+  beforeAll(async () => {
+    await page.goto('http://localhost:8000/#/profile/create/true')
+  })
+
+  describe('shows an error message', () => {
+    it('modal displayed', async () => {
+      await expect(page).toClick('a', { text: 'Export'})
+      const sel_text = await page.$eval('#alert_text', e => e.textContent)
+      expect(sel_text).toMatch('Parts of the form are invalid')
+    })
+
+    it('closes the alert modal', async () => {
+      page
+        .waitForSelector('#alertClose')
+        .then(async () => await page.click('#alertClose'))
+        .catch(error => console.log(`promise error for closing alert modal: ${error}`))
+    })
+  })
+})

--- a/source/__tests__/integration/export-profile.test.js
+++ b/source/__tests__/integration/export-profile.test.js
@@ -1,21 +1,13 @@
-const path = require('path')
-
-describe('Sinopia Profile Editor exports a loaded Profile', () => {
+describe('Sinopia Profile Editor exports an edited profile', () => {
 
   beforeAll(async () => {
-    await page.goto('http://127.0.0.1:8000/#/profile/create/')
+    await page.goto('http://localhost:8000/#/profile/create/true')
   })
 
-  it('error displayed when exporting profile form data', async () => {
-     await expect(page).toClick('a', { text: 'Export'})
-     const alert_box_header = await page.$eval('#alertBox > div > div > div.modal-header > h3', e => e.textContent)
-     await expect(alert_box_header).toMatch(/Error!/)
- })
-
-  describe('Exporting an existing profile', () => {
+  describe('Exporting an edited profile', () => {
 
     beforeAll(async () => {
-      // await expect(page).toClick('a', { text: 'Import'})
+      const path = require('path')
       const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item.json')
       await expect(page).toUploadFile(
         'input[type="file"]',
@@ -23,11 +15,40 @@ describe('Sinopia Profile Editor exports a loaded Profile', () => {
       )
     })
 
-    it('saves a non-empty Profile', async () => {
+    it('imports an existing profile', async () => {
+      await page.waitForSelector('span[popover-title="Profile ID: profile:bf2:Item"]') // Waits for the Profile to load
+    })
+
+    it('changes some values', async () => {
       await page.waitFor(1000)
-      await expect(page).toClick('a', { text: 'Export'})
-      // TODO: test that profile written to file system (see #77)
-      // TODO: test fields that are validated, listed in source/assets/js/modules/profile/services/profileHandler.service.js
+      await page.$eval('form[name="profileForm"]', e => e.reset())
+      await expect(page).toFillForm('form[name="profileForm"]', {
+        id: "profile:my:Item",
+        description: "my item profile",
+        author: "Me",
+        title: "My Profile"
+      })
+    }, 10000)
+
+    it('exports JSON data for a non-empty Profile', async () => {
+      let data;
+
+      page.click('a.import-export').then(async () => { console.log('Export button clicked') })
+          .catch(e => console.log(`failed promise on clicking the Export button: ${e}`))
+
+      await page.waitFor(1000)
+
+      page.waitForSelector('a[download="My Profile.json"]')
+          .then(
+            data = await page.$eval('a[download="My Profile.json"]', e => e.getAttribute('href'))
+          )
+          .catch(e => console.log(`failed promise on download data link: ${e}`))
+
+      const json = JSON.parse(data.substr(data.indexOf(',') + 1))
+      expect(json['Profile']['id']).toBe('profile:my:Item')
+      expect(json['Profile']['description']).toBe('my item profile')
+      expect(json['Profile']['author']).toBe('Me')
+      expect(json['Profile']['title']).toBe('My Profile')
     })
   })
 })

--- a/source/assets/js/modules/profile/directives/export.directive.js
+++ b/source/assets/js/modules/profile/directives/export.directive.js
@@ -12,16 +12,25 @@ angular.module('locApp.modules.profile.controllers')
                     
                     if(scope.validateProfile()) {
                         scope.validateDate();
+                        // Sinopia: adds an ID to the anchor tag and checks for it's prior existence
+                        // in order to remove it if already exists to support subsequent downloads.
+                        // This is because we need to run an integration test on the JSON produced,
+                        // so the node cannot be immediately removed after it is clicked below...
+                        var existingAnchorNode = document.getElementById('downloadAnchorNode');
+                        if (existingAnchorNode != null) {
+                          existingAnchorNode.remove();
+                        }
                         var raw = FormHandler.getFormData(scope.profile, attrs.sssExport === "brief");
                         var name = ProfileHandler.getName(raw) + ".json";
                         var json = angular.toJson(raw);
                         var dataStr = "data:text/json; charset=utf-8," + json;
                         var downloadAnchorNode = document.createElement('a');
+                        downloadAnchorNode.setAttribute("id", 'downloadAnchorNode');
                         downloadAnchorNode.setAttribute("href", dataStr);
                         downloadAnchorNode.setAttribute("download", name);
                         document.body.appendChild(downloadAnchorNode); // required for firefox
                         downloadAnchorNode.click();
-                        downloadAnchorNode.remove();
+                        //downloadAnchorNode.remove();
                     }
                     //Make sure the alert dialogs appear
                     scope.$digest();


### PR DESCRIPTION
Fixes #98 

These tests validate the exported profile:
- Check whether the alert modal displays if the profile is invalid (has missing data fields)
- Checks whether the modified profile data gets written to the exported JSON

Requires modification to the angular export directive to allow the anchor node with the JSON data to persist after it is created as a DOM element. Instead, we check whether it previously exists and then remove it at the outset, requiring an addition of an element ID.

Also ignore `eslint` warnings for `document` and `console`