### PR TITLE
Removes verso as git submodule 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ jobs:
           root: dist
           paths: assets
       - run:
-          name: get profiles static data via git submodule
-          command: npm run git-submodule
-      - run:
           name: test with jest and puppeteer
           command: npm run jest-ci
           environment:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sample_data_from_verso"]
-	path = sample_data_from_verso
-	url = git@github.com:lcnetdev/verso.git

--- a/package.json
+++ b/package.json
@@ -51,9 +51,8 @@
   },
   "scripts": {
     "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js",
-    "dev-test": "npm install && npm run grunt-dev && npm run git-submodule && jest --colors",
+    "dev-test": "npm install && npm run grunt-dev && jest --colors",
     "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
-    "git-submodule": "git submodule init && git submodule update",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
     "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors",

--- a/sample_data_from_verso/README.md
+++ b/sample_data_from_verso/README.md
@@ -1,0 +1,47 @@
+# Sinopia Sample Data from verso
+This directory and sub-directories contain JSON Profiles and the language RDF XML
+from the Library of Congress [Verso][VERSO] middleware source code repository 
+that is used in the Sinopia Profile Editor project. 
+
+## Log
+
+### 2018-10-31
+Add README.md
+
+### 2018-10-30 
+Initial import of the latest profiles in [Verso][VERSO]. Here is the listing of
+profiles from the SHA commit 67786e709e2aa207f6605e6a484b69d01acb9a60.
+
+	BIBFRAME 2.0 Admin Metadata.json
+	BIBFRAME 2.0 Agents Contribution.json
+	BIBFRAME 2.0 Agents Primary Contribution.json
+	BIBFRAME 2.0 Agents.json
+	BIBFRAME 2.0 Cartographic.json
+	BIBFRAME 2.0 DDC.json
+	BIBFRAME 2.0 Extra menus.json
+	BIBFRAME 2.0 Form.json
+	BIBFRAME 2.0 Identifiers.json
+	BIBFRAME 2.0 Item.json
+	BIBFRAME 2.0 LCC.json
+	BIBFRAME 2.0 Language.json
+	BIBFRAME 2.0 Monograph.json
+	BIBFRAME 2.0 Moving Image-35mm Feature Film.json
+	BIBFRAME 2.0 Moving Image-BluRay DVD.json
+	BIBFRAME 2.0 Notated Music.json
+	BIBFRAME 2.0 Note.json
+	BIBFRAME 2.0 Place.json
+	BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
+	BIBFRAME 2.0 RWO.json
+	BIBFRAME 2.0 Rare Materials.json
+	BIBFRAME 2.0 Related Works and Expressions.json
+	BIBFRAME 2.0 Serial.json
+	BIBFRAME 2.0 Series Information.json
+	BIBFRAME 2.0 Sound Recording-Analog.json
+	BIBFRAME 2.0 Sound Recording-Audio CD-R.json
+	BIBFRAME 2.0 Sound Recording-Audio CD.json
+	BIBFRAME 2.0 Title Information.json
+	BIBFRAME 2.0 Topic.json
+	PMO Medium of Performance.json
+ 
+
+[VERSO]: https://github.com/lcnetdev/verso 

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Admin Metadata.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Admin Metadata.json
@@ -1,0 +1,426 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": "http://id.loc.gov/ontologies/bflc/catalogerId"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerId",
+                        "propertyLabel": "Your cataloger ID (Windows ID)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": "Date or date and time on which the original metadata first created."
+                            },
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creation date",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": "Date or date and time on which the metadata was modified."
+                            },
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
+                        "propertyLabel": "Change date"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/organizations"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "editable": "false",
+                            "repeatable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Assigning agency",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/marcauthen"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc",
+                                    "defaultLiteral": "pcc"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description authentication",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/descriptionConventions"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
+                            },
+                            "editable": "false",
+                            "repeatable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                                    "defaultLiteral": "rda"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description conventions",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                                "dataTypeLabel": ""
+                            },
+                            "editable": "false",
+                            "repeatable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                                    "defaultLiteral": "English"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description language",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description modifier",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionModifier"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/menclvl"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Encoding level",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/encodingLevel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/profile",
+                        "propertyLabel": "Profile",
+                        "remark": "The profile code for the resource"
+                    }
+                ],
+                "id": "profile:bf2:AdminMetadata",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+                "resourceLabel": "BIBFRAME 2.0 Admin Metadata"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerId",
+                        "propertyLabel": "Your cataloger ID (Windows ID)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate",
+                        "propertyLabel": "Creation date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
+                        "propertyLabel": "Change date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata2:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Assigning agency"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/marcauthen"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc",
+                                    "defaultLiteral": "pcc"
+                                }
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication",
+                        "propertyLabel": "Description authentication"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/descriptionConventions"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                                    "defaultLiteral": "RDA"
+                                }
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
+                        "propertyLabel": "Description conventions"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                                    "defaultLiteral": "English"
+                                }
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage",
+                        "propertyLabel": "Description language"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata2:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionModifier",
+                        "propertyLabel": "Description modifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/menclvl"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/encodingLevel",
+                        "propertyLabel": "Encoding level"
+                    }
+                ],
+                "id": "profile:bf2:AdminMetadata2",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+                "resourceLabel": "Admin Metadata Test"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/organizations"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Source/Agent"
+                    }
+                ],
+                "id": "profile:bf2:AdminMetadata2:Source",
+                "resourceLabel": "Source/Agent",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+            }
+        ],
+        "id": "profile:bf2:AdminMetadata",
+        "title": "BIBFRAME 2.0 Admin Metadata",
+        "description": "Metadata for BIBFRAME Resources",
+        "date": "2017-05-20",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Agents Contribution.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Agents Contribution.json
@@ -1,0 +1,96 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Contribution",
+                "id": "profile:bf2:Agents:Contribution",
+                "resourceLabel": "Contribution",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Agent",
+                        "valueConstraint": {
+                            "repeatable": "true",
+                            "useValuesFrom": [],
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Person",
+                                "profile:bf2:Agent:Family",
+                                "profile:bf2:Agent:CorporateBody",
+                                "profile:bf2:Agent:Jurisdiction",
+                                "profile:bf2:Agent:Conference"
+                            ],
+                            "editable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "type": "resource",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": []
+                    },
+                    {
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
+                        "propertyLabel": "Relationship Designator (RDA Appendix I)",
+                        "type": "resource",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Role"
+                            ],
+                            "useValuesFrom": [],
+                            "editable": "true",
+                            "repeatable": "true"
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdaappi_rdai-34.html"
+                    }
+                ]
+            },
+            {
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Contribution",
+                "id": "profile:bf2:Agents:bfContribution",
+                "resourceLabel": "Contribution (test)",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Agent",
+                        "valueConstraint": {
+                            "repeatable": "true",
+                            "useValuesFrom": [],
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:bfPerson",
+                                "profile:bf2:Agent:Family",
+                                "profile:bf2:Agent:CorporateBody",
+                                "profile:bf2:Agent:Jurisdiction",
+                                "profile:bf2:Agent:Conference"
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "type": "resource",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": []
+                    },
+                    {
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
+                        "propertyLabel": "Relationship Designator (RDA Appendix I)",
+                        "type": "resource",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Role"
+                            ],
+                            "useValuesFrom": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdaappi_rdai-34.html"
+                    }
+                ]
+            }
+        ],
+        "id": "profile:bf2:AgentsContribution",
+        "title": "BIBFRAME 2.0 Agents Contribution",
+        "date": "2017-05-13",
+        "description": "Creators and Contributors",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Agents Primary Contribution.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Agents Primary Contribution.json
@@ -1,0 +1,103 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Person",
+                                "profile:bf2:Agent:Family",
+                                "profile:bf2:Agent:CorporateBody",
+                                "profile:bf2:Agent:Jurisdiction",
+                                "profile:bf2:Agent:Conference"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Primary Contributor"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Role"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "false",
+                            "defaults": [],
+                            "editable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
+                        "propertyLabel": "Relationship Designator (RDA Appendix I)",
+                        "remark": "http://access.rdatoolkit.org/rdaappi_rdai-34.html"
+                    }
+                ],
+                "id": "profile:bflc:Agents:PrimaryContribution",
+                "resourceLabel": "Primary Contribution",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:bfPerson",
+                                "profile:bf2:Agent:Family",
+                                "profile:bf2:Agent:CorporateBody",
+                                "profile:bf2:Agent:Jurisdiction",
+                                "profile:bf2:Agent:Conference"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Primary Contributor"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Role"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
+                        "propertyLabel": "Relationship Designator (RDA Appendix I)",
+                        "remark": "http://access.rdatoolkit.org/rdaappi_rdai-34.html"
+                    }
+                ],
+                "id": "profile:bflc:Agents:bfPrimaryContribution",
+                "resourceLabel": "Primary Contribution (test)",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+            }
+        ],
+        "contact": "NDMSO",
+        "id": "profile:bflc:PrimaryContribution",
+        "title": "BIBFRAME 2.0 Agents Primary Contribution",
+        "description": "Primary Contribution",
+        "date": "2017-07-18"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Agents.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Agents.json
@@ -1,0 +1,1679 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#PersonalName",
+                "id": "profile:bf2:Agent:Person",
+                "resourceLabel": "Person",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search LCNAF",
+                        "valueConstraint": {
+                            "repeatable": "true",
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "valueLanguage": "",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#PersonalName",
+                        "type": "lookup",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": []
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#PersonalName"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Preferred Name for Person (RDA 9.2.2) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-822.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#fullerName",
+                        "propertyLabel": "Fuller Form of Name (RDA 9.5) CORE IF ...",
+                        "remark": "http://www.loc.gov/mads/rdf/v1#"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:RWO"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#identifiesRWO",
+                        "propertyLabel": "Other Identifying Attributes (RDA 9.6-9.11)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Addresses",
+                                "profile:bf2:Agents:Addresses:Extended"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Address of Person (RDA 9.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasAffiliationAddress"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#note",
+                        "propertyLabel": "Biographical Information (RDA 9.17)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5392.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Identifier"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Identifier for the Person (RDA 9.18)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5421.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:VariantAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant",
+                        "propertyLabel": "Variant Access Point Representing a Person (RDA 9.19.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5726.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RelatedAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Agents (RDA Chapter 30)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority",
+                        "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Consulted (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource"
+                    }
+                ],
+                "contact": "",
+                "remark": ""
+            },
+            {
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
+                "id": "profile:bf2:Agent:Family",
+                "resourceLabel": "Family",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search LCNAF",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
+                        "type": "lookup",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": []
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Preferred Name for Family (RDA 10.2.2) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-241.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-468.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#FamilyNameElement",
+                        "propertyLabel": "Type of Family (RDA 10.3) CORE ELEMENT"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Dates"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Date Associated with Family (RDA 10.4)",
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-487.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#DateNameElement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:OtherPlace"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale",
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-516.html",
+                        "propertyLabel": "Place Associated with Family (RDA 10.5)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Prominent Member of Family (RDA 10.6)",
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-549.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#prominentFamilyMember"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-592.html",
+                        "propertyLabel": "Hereditary Title (RDA 10.7)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#honoraryTitle"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:AssociatedLanguage"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-9952.html",
+                        "propertyLabel": "Language of Family (RDA 10.8)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLanguage"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-625.html",
+                        "propertyLabel": "Family History (RDA 10.9)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Identifier"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-657.html",
+                        "propertyLabel": "Identifier for Family (RDA 10.10)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:IdentifiedbyAuthority"
+                            ],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point Representing the Family (RDA 10.11.1)",
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-678.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:VariantAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant",
+                        "propertyLabel": "Variant Access Point Representing the Family (RDA 10.11.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-761.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RelatedAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Agents (RDA Chapter 30)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority",
+                        "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Consulted (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource"
+                    }
+                ]
+            },
+            {
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#CorporateName",
+                "id": "profile:bf2:Agent:CorporateBody",
+                "resourceLabel": "Corporate Body",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search LCNAF",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#CorporateName",
+                        "type": "lookup",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": []
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Preferred Name for Corporate Body (RDA 11.2.2) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-1207.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:OtherPlace"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale",
+                        "propertyLabel": "Place Associated with Corporate Body (RDA 11.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4146.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Dates"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Date Associated with Corporate Body (RDA 11.4) CORE ELEMENT",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#establishDate",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4502.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Affiliation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Associated Institution (RDA 11.5)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4671.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#organization"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Designation Associated with Corporate Body (RDA 11.7)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#entityDescriptor",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4726.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:AssociatedLanguage"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Language of Corporate Body (RDA 11.8)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLanguage",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4992.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Addresses",
+                                "profile:bf2:Agents:Addresses:Extended"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Address of Corporate Body (RDA 11.9)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5024.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasAffiliationAddress"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:FieldofActivity"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Field of Activity of Corporate Body (RDA 11.10)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5056.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Corporate History (RDA 11.11)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5084.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Identifier"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Identifier for the Corporate Body (RDA 11.12) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5119.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point for the Corporate Body (RDA 11.13.1)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5161.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:VariantAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Variant Access Point Representing a Corporate Body (RDA 11.13.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5591.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RelatedAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Agents (RDA Chapter 30)",
+                        "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Consulted (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource"
+                    }
+                ]
+            },
+            {
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#ConferenceName",
+                "id": "profile:bf2:Agent:Conference",
+                "resourceLabel": "Conference",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search LCNAF",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#ConferenceName",
+                        "type": "lookup",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": []
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Preferred Name for Conference (RDA 11.2.2) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-1207.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:LocationOfConference",
+                                "profile:bf2:Agents:RWO:OtherPlace"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Place Associated with Conference (RDA 11.3) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4146.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Dates"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4502.html",
+                        "propertyLabel": "Date Associated with Conference (RDA 11.4) CORE ELEMENT",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#establishDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Affiliation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4671.html",
+                        "propertyLabel": "Associated Institution (RDA 11.5) CORE IF ...",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#organization"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-10741.html",
+                        "propertyLabel": "Number of a Conference, Etc. (RDA 11.6) CORE ELEMENT",
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4726.html",
+                        "propertyLabel": "Other Designation Associated with Conference (RDA 11.7) CORE IF ...",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#entityDescriptor"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:AssociatedLanguage"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4993.html",
+                        "propertyLabel": "Language of Conference (RDA 11.8)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLanguage"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:FieldofActivity"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5056.html",
+                        "propertyLabel": "Field of Activity of Conference (RDA 11.10)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5084.html",
+                        "propertyLabel": "Conference History (RDA 11.11)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Identifier"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier",
+                        "propertyLabel": "Identifier for the Conference (RDA 11.12) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5119.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point for the Conference (RDA 11.13.1)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5161.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:VariantAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Variant Access Point Representing a Conference (RDA 11.13.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5591.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RelatedAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Agents (RDA Chapter 30)",
+                        "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource",
+                        "propertyLabel": "Source Consulted (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html"
+                    }
+                ]
+            },
+            {
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                "id": "profile:bf2:Agent:Jurisdiction",
+                "resourceLabel": "Jurisdiction",
+                "propertyTemplates": [
+                    {
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                        "propertyLabel": "Search LCNAF",
+                        "type": "lookup",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Preferred Name for Place (RDA 16.2.2)",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "remark": "http://access.rdatoolkit.org/rdachp16_rda16-322.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Identifier"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier",
+                        "propertyLabel": "Identifier for Place (RDA 9.18)",
+                        "remark": "http://access.rdatoolkit.org/rdachp16_rda16-768.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point for the Place (RDA 11.13.1.1)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5163.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:VariantAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Variant Access Point Representing the Place (RDA 11.13.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5591.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RelatedAgents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Agents (RDA Chapter 30)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority",
+                        "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Consulted (RDA 8.12)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html"
+                    }
+                ],
+                "contact": ""
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/organizations"
+                            ],
+                            "valueDataType": {},
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Record Content Source",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordContentSource",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordcontentsource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Creation Date",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordCreationDate",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordcreationdate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordChangeDate",
+                        "propertyLabel": "Record Change Date",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordchangedate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Identifier",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordIdentifier",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordidentifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Origin",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordOrigin",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordorigin"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Info Note",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordInfoNote",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recorinfonote"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {},
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                                    "defaultLiteral": "eng"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Language of Cataloging",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#languageOfCataloging",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#languageofcataloging"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/descriptionConventions"
+                            ],
+                            "valueDataType": {},
+                            "editable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                                    "defaultLiteral": "rda"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description Standard",
+                        "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#descriptionStandard",
+                        "remark": "https://www.loc.gov/standards/mods/userguide/recordinfo.html#descriptionstandard"
+                    }
+                ],
+                "id": "profile:bf2:Agents:AdminMetadata",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#adminMetadata",
+                "resourceLabel": "Admin Metadata",
+                "remark": "This relates an Authority or Variant to its administrative metadata, which is, minimimally, a Class defined outside of the MADS/RDF namespace. The RecordInfo Class from the RecordInfo ontology is recommended."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Address of Person (RDA 9.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#Address"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Email Address of Person",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#email"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Address of Corporate Body (RDA 11.9)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#AffiliationAddress",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5022.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Email Address of Corporate Body",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#email"
+                    }
+                ],
+                "id": "profile:bf2:Agents:Addresses",
+                "resourceLabel": "Addresses",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Address"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Street Address 1",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#streetAddress"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Street Address 2",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#extendedAddress"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "City",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#city"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "State",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#state"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Country",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#country"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Zip Code or Post Code",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#postcode"
+                    }
+                ],
+                "id": "profile:bf2:Agents:Addresses:Extended",
+                "resourceLabel": "Addresses, Extended",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Address"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Authority"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search agents",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Role"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Role"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Relationship Designator (RDA Appendix K)",
+                        "remark": "http://access.rdatoolkit.org/rdaappk_rdak-15.html",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    }
+                ],
+                "resourceLabel": "Related Agents",
+                "id": "profile:bf2:Agents:RelatedAgents",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Authority"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#citationSource",
+                        "propertyLabel": "Source Consulted (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Consulted Note (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#citationNote"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Citation Status (RDA 8.12)",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#citationStatus"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Cataloger's Note (RDA 8.13)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#editorialNote",
+                        "remark": "http://access.rdatoolkit.org/rdachp8_rda8-531.html"
+                    }
+                ],
+                "resourceLabel": "Sources Consulted and Cataloger's Notes",
+                "id": "profile:bf2:Agents:Source",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Source"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant",
+                        "propertyLabel": "Variant Access Point Representing an Agent",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5726.html"
+                    }
+                ],
+                "id": "profile:bf2:Agents:VariantAgents",
+                "resourceLabel": "Variant Access Points Representing Agents",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#hasVariant"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/relators"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search MARC relator term",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Role"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Input RDA relationship designator term (if it does not appear above)"
+                    }
+                ],
+                "id": "profile:bf2:Agent:Role",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Role",
+                "resourceLabel": "Role"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Identifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Identifier:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source of identifier"
+                    }
+                ],
+                "id": "profile:bf2:Agent:Identifier",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Identifier",
+                "resourceLabel": "Identifier"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Note"
+                    }
+                ],
+                "id": "profile:bf2:Agent:Note",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#note",
+                "resourceLabel": "Note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Source of identifier"
+                    }
+                ],
+                "id": "profile:bf2:Agent:Identifier:Source",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Source",
+                "resourceLabel": "Source"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCNAF",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Person"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Person"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Preferred Name for Person (RDA 9.2.2) CORE ELEMENT"
+                    }
+                ],
+                "id": "profile:bf2:Agent:bfPerson",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Person",
+                "resourceLabel": "Bibframe Person"
+            }
+        ],
+        "id": "profile:bf2:Agents:Attributes",
+        "title": "BIBFRAME 2.0 Agents",
+        "date": "2017-05-22",
+        "description": "Agents are people, organizations, jurisdictions, etc., associated with a Work or Instance through roles such as author, editor, artist, photographer, composer, illustrator, etc."
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Cartographic.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Cartographic.json
@@ -1,0 +1,1777 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": [],
+                            "editable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Coordinates"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
+                        "propertyLabel": "Coordinates of Cartographic Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": [],
+                            "editable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                                    "defaultLiteral": "cartographic image"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Script"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Scale"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/scale",
+                        "propertyLabel": "Scale information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Projection"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
+                        "propertyLabel": "Projection of Cartographic Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "Time Period of Content (MARC 045 field)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:Cartographic:Instance",
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Instance Of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Work"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "remark": "http://access.rdatoolkit.org/2.5.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:ManufactureInformation",
+                                "profile:bf2:DistributionInformation"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "remark": "http://access.rdatoolkit.org/2.11.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Series Statement",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "remark": "http://access.rdatoolkit.org/2.13.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "valueTemplateRefs": [],
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Identifier for the Manifestation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Notes about the Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "remark": "http://access.rdatoolkit.org/3.2.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "valueTemplateRefs": [],
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                                    "defaultLiteral": "unmediated"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "remark": "http://access.rdatoolkit.org/3.3.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "valueTemplateRefs": [],
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                    "defaultLiteral": "volume"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "remark": "http://access.rdatoolkit.org/3.5.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mlayout"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Layout"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Layout (RDA 3.11)",
+                        "remark": "http://access.rdatoolkit.org/3.11.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/layout"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mpolarity"
+                            ],
+                            "valueDataType": {
+                                "dataTypeLabel": "Polarity",
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Polarity"
+                            },
+                            "editable": "true",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Polarity (RDA 3.14)",
+                        "remark": "http://access.rdatoolkit.org/3.14.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/polarity"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:DataType",
+                                "profile:bf2:Cartographic:ObjectType"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Digital File Characteristic (RDA 3.19)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/digitalCharacteristic",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "remark": "http://access.rdatoolkit.org/4.6.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Class"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Geographic Classification (MARC 052)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contributors (RDA 21.1)",
+                        "remark": "http://access.rdatoolkit.org/21.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Instances"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                        "propertyLabel": "Administrative Metadata for Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Has Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "propertyLabel": "Held by"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Shelving call numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/shelfmark",
+                        "propertyLabel": "Copy, issue, offprint number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Barcode"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "propertyLabel": "Electronic location"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "propertyLabel": "Held in sublocation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item",
+                "resourceLabel": "BIBFRAME Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/coordinates",
+                        "propertyLabel": "Coordinates (RDA 7.4)",
+                        "remark": "http://access.rdatoolkit.org/7.4.html"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:Coordinates",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Cartographic",
+                "resourceLabel": "Cartographic Coordinates"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Cartographic Data Type",
+                        "remark": "http://access.rdatoolkit.org/3.19.8.5.html"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/CartographicDataType",
+                "id": "profile:bf2:Cartographic:DataType",
+                "remark": "",
+                "resourceLabel": "Cartographic Data Type"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Cartographic Object Type",
+                        "remark": "http://access.rdatoolkit.org/3.19.8.html"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:ObjectType",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/CartographicObjectType",
+                "resourceLabel": "Cartographic Object Type"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Projection"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
+                        "propertyLabel": "Projection (RDA 7.26)",
+                        "remark": "http://access.rdatoolkit.org/7.26.html"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:Projection",
+                "resourceLabel": "Cartographic Projection",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Cartographic"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Scale"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Scale (RDA 7.25)",
+                        "remark": "http://access.rdatoolkit.org/7.25.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Additional Scale Information"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:Scale",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Scale",
+                "resourceLabel": "Scale"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Geographic Classification"
+                    }
+                ],
+                "id": "profile:bf2:Cartographic:Class",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Classification",
+                "resourceLabel": "Geographic Classification"
+            },
+            {
+                "id": "profile:bf2:Cartographic:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "false",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Coordinates of Cartographic Content (RDA 7.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
+                        "remark": "http://access.rdatoolkit.org/7.4.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Coordinates"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "remark": "http://access.rdatoolkit.org/7.7.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "valueTemplateRefs": [],
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaultURI": "",
+                            "defaultLiteral": "",
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-11.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-64.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Contents"
+                            ],
+                            "defaults": []
+                        },
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Expression"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "",
+                                "dataTypeLabel": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Your Windows ID and Comments",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                ""
+                            ],
+                            "defaults": []
+                        }
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
+            },
+            {
+                "id": "profile:bf2:Cartographic:ExpressionOld",
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules.",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "remark": "http://access.rdatoolkit.org/6.9.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "valueTemplateRefs": [],
+                            "editable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                                    "defaultLiteral": "cartographic image"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.10.html",
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "remark": "http://access.rdatoolkit.org/6.11.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "valueTemplateRefs": [],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Cartographic:Scale"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/scale",
+                        "propertyLabel": "Scale information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
+                        "propertyLabel": "Projection of Cartographic Content (RDA 7.26)",
+                        "remark": "http://access.rdatoolkit.org/7.26.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.27.html",
+                        "propertyLabel": "Other Details of Cartographic Content (RDA 7.27)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Time Period of Content (MARC 045 field)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage"
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "propertyLabel": "Notes about the Expression",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "remark": "",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "defaults": []
+                        }
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
+                        "remark": "http://access.rdatoolkit.org/6.27.3.html",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-18",
+        "description": "Work, Expression, Instance for Cartographic",
+        "id": "profile:bf2:Cartographic",
+        "remark": "",
+        "title": "BIBFRAME 2.0 Cartographic"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 DDC.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 DDC.json
@@ -1,0 +1,51 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classificationPortion",
+                        "propertyLabel": "DDC Classification number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/classSchemes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/edition"
+                            },
+                            "defaultURI": "",
+                            "defaultLiteral": "",
+                            "editable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/edition",
+                        "propertyLabel": "Dewey Edition"
+                    }
+                ],
+                "id": "profile:bf2:DDC",
+                "resourceLabel": "Dewey Decimal Classification",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
+            }
+        ],
+        "id": "profile:bf2:DDC",
+        "description": "Dewey Decimal Classification",
+        "title": "BIBFRAME 2.0 DDC",
+        "date": "2017-07-28",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Extra menus.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Extra menus.json
@@ -1,0 +1,872 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mbroadstd"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Broadcast Standard (RDA 3.18.3)",
+                        "remark": "http://access.rdatoolkit.org/3.18.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Broadcast Standard (RDA 3.18.3.4)",
+                        "remark": "http://access.rdatoolkit.org/3.18.3.4.html"
+                    }
+                ],
+                "id": "profile:bf2:BroadStd",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard",
+                "resourceLabel": "Broadcast Standard"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
+                        "propertyLabel": "Place of Capture (RDA 7.11.2)",
+                        "remark": "http://access.rdatoolkit.org/7.11.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date of Capture (RDA 7.11.3)",
+                        "remark": "http://access.rdatoolkit.org/7.11.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Capture note"
+                    }
+                ],
+                "id": "profile:bf2:Capture",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
+                "resourceLabel": "Capture information"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Digital File Characteristic (RDA 3.19.1.4)",
+                        "remark": "http://access.rdatoolkit.org/3.19.1.4.html"
+                    }
+                ],
+                "id": "profile:bf2:DigChar",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic",
+                "resourceLabel": "Digital Characteristics"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Encoding Format (RDA 3.19.3)",
+                        "remark": "http://access.rdatoolkit.org/3.19.3.html"
+                    }
+                ],
+                "id": "profile:bf2:EncFmt",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/EncodingFormat",
+                "resourceLabel": "Encoding Format"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Extent (RDA 3.4)",
+                        "remark": "http://access.rdatoolkit.org/3.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on extent"
+                    }
+                ],
+                "id": "profile:bf2:Extent",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
+                "resourceLabel": "Extent"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "File Size (RDA 3.19.4)",
+                        "remark": "http://access.rdatoolkit.org/3.19.4.html"
+                    }
+                ],
+                "id": "profile:bf2:FileSize",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileSize",
+                "resourceLabel": "File Size"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mfiletype"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/FileType"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "File Type (RDA 3.19.2)",
+                        "remark": "http://access.rdatoolkit.org/3.19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of File Type (RDA 3.19.2.4)",
+                        "remark": "http://access.rdatoolkit.org/3.19.2.4.html"
+                    }
+                ],
+                "id": "profile:bf2:FileType",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileType",
+                "resourceLabel": "File Type"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about Audience"
+                    }
+                ],
+                "id": "profile:bf2:Audience",
+                "resourceLabel": "Intended Audience",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mplayback"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
+                        "remark": "http://access.rdatoolkit.org/3.16.8.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
+                        "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
+                    }
+                ],
+                "id": "profile:bf2:Playback",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
+                "resourceLabel": "Playback Channels"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Playing Speed (RDA 3.16.4)",
+                        "remark": "http://access.rdatoolkit.org/3.16.4.html"
+                    }
+                ],
+                "id": "profile:bf2:PlayingSpeed",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlayingSpeed",
+                "resourceLabel": "Playing Speed"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mproduction"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "",
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Production Method (RDA 3.9.1.3)",
+                        "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Production Method (RDA 3.9.1.4)",
+                        "remark": "http://access.rdatoolkit.org/3.9.1.4.html"
+                    }
+                ],
+                "id": "profile:bf2:ProdMeth",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod",
+                "resourceLabel": "Production Method"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mrecmedium"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mrecmedium/opt",
+                                    "defaultLiteral": "optical"
+                                }
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium"
+                            }
+                        },
+                        "propertyLabel": "Recording Medium (RDA 3.16.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "remark": "http://access.rdatoolkit.org/3.16.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
+                        "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
+                    }
+                ],
+                "id": "profile:bf2:RecMedium",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
+                "resourceLabel": "Recording Medium"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mregencoding"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RegionalEncoding"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Regional Encoding (RDA 3.19.6.3)",
+                        "remark": "http://access.rdatoolkit.org/3.19.6.3.html"
+                    }
+                ],
+                "id": "profile:bf2:RegEncoding",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/RegionalEncoding",
+                "resourceLabel": "Regional Encoding"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Resolution (RDA 3.19.5)",
+                        "remark": "http://access.rdatoolkit.org/3.19.5.html"
+                    }
+                ],
+                "id": "profile:bf2:Resolution",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Resolution",
+                "resourceLabel": "Resolution"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/msoundcontent"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/msoundcontent/sound",
+                                    "defaultLiteral": "sound"
+                                }
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SoundContent"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Sound Content (RDA 7.18)",
+                        "remark": "http://access.rdatoolkit.org/7.18.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Sound Content (RDA 7.18)",
+                        "remark": "http://access.rdatoolkit.org/7.18.html"
+                    }
+                ],
+                "id": "profile:bf2:SoundContent",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/SoundContent",
+                "resourceLabel": "Sound Content"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mspecplayback"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
+                        "remark": "http://access.rdatoolkit.org/3.16.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Playback Characteristic"
+                    }
+                ],
+                "id": "profile:bf2:SpecPlayback",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
+                "resourceLabel": "Special Playback Characteristic"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mrectype"
+                            ],
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mrectype/digital",
+                                    "defaultLiteral": "digital"
+                                }
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Type of Recording (RDA 3.16.2)",
+                        "remark": "http://access.rdatoolkit.org/3.16.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
+                        "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
+                    }
+                ],
+                "id": "profile:bf2:TypeRec",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
+                "resourceLabel": "Type of Recording"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "LCMPT for Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+                        "propertyLabel": "Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrumentalType",
+                        "propertyLabel": "Type of instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note"
+                    }
+                ],
+                "id": "profile:bf2:MOPInstrument",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument",
+                "resourceLabel": "Instrument"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "LCMPT for Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+                        "propertyLabel": "Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voiceType",
+                        "propertyLabel": "Type of voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note"
+                    }
+                ],
+                "id": "profile:bf2:MOPVoice",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice",
+                "resourceLabel": "Voice"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "LCMPT for Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+                        "propertyLabel": "Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensembleType",
+                        "propertyLabel": "Type of Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note"
+                    }
+                ],
+                "id": "profile:bf2:MOPEnsemble",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble",
+                "resourceLabel": "Ensemble"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Medium of Performance (RDA 7.21)",
+                        "remark": "http://access.rdatoolkit.org/7.21.html"
+                    }
+                ],
+                "id": "profile:bf2:MOPStatement",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
+                "resourceLabel": "Medium of Performance Statement"
+            }
+        ],
+        "id": "profile:bf2:Xtras",
+        "title": "BIBFRAME 2.0 Extra menus",
+        "date": "2018-09-26",
+        "contact": "NDMSO",
+        "description": "Extra submenus for format profiles"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Form.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Form.json
@@ -1,0 +1,104 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/genreForms"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false"
+                        },
+                        "propertyLabel": "Search LCGFT (RDA 6.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                        "remark": "http://access.rdatoolkit.org/6.3.html"
+                    }
+                ],
+                "id": "profile:bf2:Form",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                "resourceLabel": "Form/Genre",
+                "contact": "NDMSO"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "",
+                                "remark": ""
+                            },
+                            "repeatable": "false",
+                            "remark": ""
+                        },
+                        "propertyLabel": "(Geographic) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about Geographic coverage"
+                    }
+                ],
+                "id": "profile:bf2:Form:Geog",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GeographicCoverage",
+                "resourceLabel": "Geographic coverage"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/genreForms"
+                            ],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Search LCGFT",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+                    }
+                ],
+                "id": "profile:bf2:FormTest",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                "resourceLabel": "Form/Genre Test"
+            }
+        ],
+        "id": "profile:bf2:Form",
+        "title": "BIBFRAME 2.0 Form",
+        "description": "Form of Work",
+        "date": "2017-05-13",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Identifiers.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Identifiers.json
@@ -1,0 +1,1472 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Barcode",
+                        "propertyLabel": "Barcode"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Copyright"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/CopyrightRegistration",
+                        "propertyLabel": "Copyright Registration Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:EAN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "EAN",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Ean"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Eidr"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/Eidr",
+                        "propertyLabel": "EIDR"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Isbn",
+                        "propertyLabel": "ISBN"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISMN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Ismn",
+                        "propertyLabel": "ISMN"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TestProfile:ISRC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Isrc",
+                        "propertyLabel": "ISRC"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISSN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Issn",
+                        "propertyLabel": "ISSN"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISSNL"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/IssnL",
+                        "propertyLabel": "ISSN-L"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LCCN",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Lccn"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Distributor"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/StockNumber",
+                        "propertyLabel": "Music Distributor Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:MusicPlate"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/MusicPlate",
+                        "propertyLabel": "Music Plate Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:MusicPub"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/MusicPublisherNumber",
+                        "propertyLabel": "Music Publisher Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:PubNumber"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/PublisherNumber",
+                        "propertyLabel": "Publisher Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:STRN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Strn",
+                        "propertyLabel": "Standard Technical Report Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:UPC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Upc",
+                        "propertyLabel": "Universal Product Code (UPC)"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Identifier",
+                "resourceLabel": "Identifiers"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Barcode"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Barcode",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Barcode",
+                "resourceLabel": "Barcode"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Copyright Registration Number",
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Assigning agency"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Copyright Registration"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Copyright",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/CopyrightRegistration",
+                "resourceLabel": "Copyright Registration Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "EAN",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on EAN"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:EAN",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Ean",
+                "resourceLabel": "EAN"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "EIDR"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on EIDR"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Eidr",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Eidr",
+                "resourceLabel": "EIDR"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "GTIN-14 number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about GTIN-14"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Gtin14",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Gtin14Number",
+                "resourceLabel": "GTIN-14"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "ISBN (RDA 2.15)",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on ISBN"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mstatus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+                        "propertyLabel": "Incorrect, Invalid or Canceled?"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:ISBN",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Isbn",
+                "resourceLabel": "ISBN"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "ISMN",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on ISMN"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:ISMN",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Ismn",
+                "resourceLabel": "ISMN"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "ISRC",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on ISRC"
+                    }
+                ],
+                "id": "profile:bf2:TestProfile:ISRC",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Isrc",
+                "resourceLabel": "ISRC"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "ISSN",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Assigning agency"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on ISSN"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mstatus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+                        "propertyLabel": "Incorrect, Invalid or Canceled?"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:ISSN",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Issn",
+                "resourceLabel": "ISSN"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "ISSN-L",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Assigning agency"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on ISSN-L"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mstatus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+                        "propertyLabel": "Incorrect, Invalid or Canceled?"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:ISSNL",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/IssnL",
+                "resourceLabel": "ISSN-L"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "LCCN",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mstatus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+                        "propertyLabel": "Invalid/Canceled?"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:LCCN",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Lccn",
+                "resourceLabel": "LCCN"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Local system number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source of number (e.g. OCLC)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on local system number"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Local",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Local",
+                "resourceLabel": "Local system number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Matrix Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Matrix Number"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Matrix",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MatrixNumber",
+                "resourceLabel": "Matrix Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Music Distributor Number",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source of Number",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Distributor",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicDistributorNumber",
+                "resourceLabel": "Music Distributor Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Music Plate Number",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Publisher Name"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Music Plate Number"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:MusicPlate",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicPlate",
+                "resourceLabel": "Music Plate Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Music Publisher Number",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Label name"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Music Publisher Number"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:MusicPub",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicPublisherNumber",
+                "resourceLabel": "Music Publisher Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Other identifier",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on other identifier"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Other",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Identifier",
+                "resourceLabel": "Other Identifier"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Publisher Number",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Label name"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Publisher Number"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:PubNumber",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/PublisherNumber",
+                "resourceLabel": "Publisher Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Standard Technical Report Number",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on STRN"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:STRN",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Strn",
+                "resourceLabel": "Standard Technical Report Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Universal Product Code (UPC)",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Universal Product Code (UPC)"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:UPC",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Upc",
+                "resourceLabel": "Universal Product Code (UPC)"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Note text",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Note",
+                "resourceLabel": "Note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Label name"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:Source",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Source",
+                "resourceLabel": "Source"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "LC shelfmark"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:LC",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ShelfMarkLcc",
+                "resourceLabel": "LC shelfmark"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "DDC shelfmark"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ShelfMarkDcc",
+                "resourceLabel": "DDC shelfmark",
+                "id": "profile:bf2:Identifiers:DDC"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Accession or copy number"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ShelfMark",
+                "id": "profile:bf2:Identifiers:Shelfmark",
+                "resourceLabel": "Accession or copy number"
+            }
+        ],
+        "id": "profile:bf2:Identifiers",
+        "title": "BIBFRAME 2.0 Identifiers",
+        "description": "Identifiers for BIBFRAME Resources",
+        "date": "2017-08-16",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Item.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Item.json
@@ -1,0 +1,274 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Barcode"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC",
+                                "profile:bf2:Identifiers:DDC",
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Call numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology",
+                        "propertyLabel": "Enumeration and chronology"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                            "defaultLiteral": "DLC"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "propertyLabel": "Held by"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "propertyLabel": "Shelving location"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "propertyLabel": "Electronic location"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/UsageAndAccessPolicy",
+                        "propertyLabel": "Usage and access policy"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/acquisitionSource",
+                        "propertyLabel": "Contact information (RDA 4.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp4_rda4-93.html"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item",
+                "resourceLabel": "BIBFRAME 2.0 Item",
+                "id": "profile:bf2:Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AccessPolicy"
+                            }
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Lending or Access Policy"
+                    }
+                ],
+                "id": "profile:bf2:Item:Access",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AccessPolicy",
+                "resourceLabel": "Lending or Access Policy"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/UsePolicy"
+                            }
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Use or Reproduction Policy"
+                    }
+                ],
+                "id": "profile:bf2:Item:Use",
+                "resourceLabel": "Use or Reproduction Policy",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/UsePolicy"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RetentionPolicy"
+                            }
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Retention Policy"
+                    }
+                ],
+                "id": "profile:bf2:Item:Retention",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/RetentionPolicy",
+                "resourceLabel": "Retention Policy"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Immediate Source of Acquisition of Item (RDA 2.19)",
+                        "remark": "http://access.rdatoolkit.org/2.19.html"
+                    }
+                ],
+                "id": "profile:bf2:Item:ImmAcqSource",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ImmediateAcquisition",
+                "resourceLabel": "Immediate Source of Acquisition"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Enumeration"
+                    }
+                ],
+                "id": "profile:bf2:Item:Enumeration",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Enumeration",
+                "resourceLabel": "Enumeration"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Chronology"
+                    }
+                ],
+                "id": "profile:bf2:Item:Chronology",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Chronology",
+                "resourceLabel": "Chronology"
+            }
+        ],
+        "id": "profile:bf2:Item",
+        "title": "BIBFRAME 2.0 Item",
+        "description": "Item for all formats (testing)",
+        "date": "2017-08-08",
+        "contact": "NDMSO",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 LCC.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 LCC.json
@@ -1,0 +1,31 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classificationPortion",
+                        "propertyLabel": "LC Classification Number"
+                    }
+                ],
+                "id": "profile:bf2:LCC",
+                "resourceLabel": "Library of Congress Classification",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationLcc"
+            }
+        ],
+        "id": "profile:bf2:LCC",
+        "title": "BIBFRAME 2.0 LCC",
+        "description": "LC Classification/Call Number",
+        "date": "2017-05-13",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Language.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Language.json
@@ -1,0 +1,82 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                                "remark": ""
+                            },
+                            "valueLanguage": "",
+                            "remark": "",
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                "id": "profile:bf2:Language2",
+                "resourceLabel": "Language",
+                "remark": ""
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Language of Content"
+                    }
+                ],
+                "id": "profile:bf2:Language:Note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                "resourceLabel": "Language of Content"
+            }
+        ],
+        "id": "profile:bf2:Language",
+        "title": "BIBFRAME 2.0 Language",
+        "date": "2017-05-13",
+        "description": "Language"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Monograph.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Monograph.json
@@ -1,0 +1,1804 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": [],
+                            "editable": "true",
+                            "repeatable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Audience"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
+                            },
+                            "defaults": [],
+                            "editable": "true",
+                            "repeatable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Dissertation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
+                        "propertyLabel": "Dissertation (RDA 7.9)",
+                        "remark": "http://access.rdatoolkit.org/7.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                    "defaultLiteral": "text"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Script"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
+                        "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    }
+                ],
+                "id": "profile:bf2:Monograph:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:Monograph:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
+                        "propertyLabel": "Series Statement",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                                    "defaultLiteral": "unmediated"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                    "defaultLiteral": "volume"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Manifestation",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item",
+                        "remark": "Item which is an example of the described Instance."
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                        "propertyLabel": "Administrative Metadata for Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/projectedProvisionDate",
+                        "propertyLabel": "Projected publication date (YYMM)",
+                        "remark": "http://id.loc.gov/ontologies/bflc.html#p_projectedProvisionDate"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+                "remark": ""
+            },
+            {
+                "id": "profile:bf2:Monograph:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Shelving call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Enumeration",
+                                "profile:bf2:Item:Chronology"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Enumeration And Chronology of Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/2.18.html",
+                        "propertyLabel": "Custodial History of Item (RDA 2.18)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/custodialHistory"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:ImmAcqSource"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
+                        "propertyLabel": "Immediate Source of Acquisition of Item",
+                        "remark": ""
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Related Manifestations (RDA 27)",
+                        "remark": "http://access.rdatoolkit.org/27.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Also issued in another format as:",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
+                        "remark": "http://access.rdatoolkit.org/J.4.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
+                        "propertyLabel": "Accompanied by (manifestation):",
+                        "remark": "http://access.rdatoolkit.org/J.4.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Reprinted as (manifestation):",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
+                        "remark": "http://access.rdatoolkit.org/J.4.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/J.4.2.html",
+                        "propertyLabel": "Reprint of (manifestation)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                        "remark": "http://access.rdatoolkit.org/J.4.html"
+                    }
+                ],
+                "id": "profile:bf2:Monograph:RelatedInstance",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+                "resourceLabel": "Related Manifestation"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/degree",
+                        "propertyLabel": "Degree"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/grantingInstitution",
+                        "propertyLabel": "Institution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Dissertation note"
+                    }
+                ],
+                "id": "profile:bf2:Monograph:Dissertation",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Dissertation",
+                "resourceLabel": "Dissertation"
+            },
+            {
+                "id": "profile:bf2:Monograph:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Audience"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Dissertation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
+                        "propertyLabel": "Dissertation (RDA 7.9)",
+                        "remark": "http://access.rdatoolkit.org/7.9.html"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Classification numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Expression elements"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Expression of",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                    "defaultLiteral": "text"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "remark": "http://access.rdatoolkit.org/6.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Summary",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyLabel": "Contributor (RDA 20.2)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Expression",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
+                        "remark": "http://access.rdatoolkit.org/6.27.3.html"
+                    }
+                ],
+                "id": "profile:bf2:Monograph:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-26",
+        "description": "Work, Expression, Instance for Monographs",
+        "id": "profile:bf2:Monograph",
+        "title": "BIBFRAME 2.0 Monograph",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Moving Image-35mm Feature Film.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Moving Image-35mm Feature Film.json
@@ -1,0 +1,1963 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Search works"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork",
+                        "propertyLabel": "History of the Work (RDA 6.7)",
+                        "remark": "http://access.rdatoolkit.org/6.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SourceConsulted"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source Consulted",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Eidr"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifiers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Audience"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                                    "defaultLiteral": "two-dimensional moving image"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Color"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent",
+                        "propertyLabel": "Sound Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "Place of capture:"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
+                        "propertyLabel": "Capture information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Event"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
+                        "propertyLabel": "Event"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
+                        "propertyLabel": "Award (RDA 7.28)",
+                        "remark": "http://access.rdatoolkit.org/7.28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Instances"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    }
+                ],
+                "id": "profile:bf2:35mmFeatureFilm:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:35mmFeatureFilm:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance Of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "resourceTemplates": [],
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Copyright",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Credits"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Cast/Credits",
+                        "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/credits"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/g",
+                                    "defaultLiteral": "projected"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/mr",
+                                    "defaultLiteral": "film reel"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mgeneration"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/3.10.html",
+                        "propertyLabel": "Recording Generation (RDA 3.10)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/generation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mpolarity"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Polarity"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Polarity (RDA 3.14.1.3)",
+                        "remark": "http://access.rdatoolkit.org/3.14.1.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/polarity"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TypeRec",
+                                "profile:bf2:RecMedium",
+                                "profile:bf2:Playback",
+                                "profile:bf2:SpecPlayback"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Sound Characteristic (RDA 3.16)",
+                        "remark": "http://access.rdatoolkit.org/3.16.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:ProjChar"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Projection Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/projectionCharacteristic"
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Persons, Families, Corporate Bodies Associated with the Manifestation (RDA 21.1.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/21.1.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SourceConsulted"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source Consulted",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Administrative Metadata for Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Has Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:35mmFeatureFilm:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC",
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/collection",
+                        "propertyLabel": "Collection"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Enumeration"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology",
+                        "propertyLabel": "Enumeration"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:ImmAcqSource"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
+                        "propertyLabel": "Immediate Source of Acquisition of Item"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Summary",
+                        "remark": "http://access.rdatoolkit.org/7.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Summary note"
+                    }
+                ],
+                "id": "profile:bf2:35mmFeatureFilm:Summary",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
+                "resourceLabel": "Summary note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Cast/credits note"
+                    }
+                ],
+                "id": "profile:bf2:35mmFeatureFilm:Credits",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits",
+                "resourceLabel": "Cast/Credits note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mcolor"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ColorContent"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Color Content (RDA 7.17.1.4)",
+                        "remark": "http://access.rdatoolkit.org/7.17.1.4.html"
+                    }
+                ],
+                "id": "profile:bf2:35mmFeatureFilm:Color",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ColorContent",
+                "resourceLabel": "Color content"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Event"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date of Event"
+                    }
+                ],
+                "id": "profile:bf2:35mmFeatureFilm:Event",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Event",
+                "resourceLabel": "Event"
+            },
+            {
+                "id": "profile:bf2:35mmFeatureFilm:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "false",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "History of the Work (RDA 6.7)",
+                        "remark": "http://access.rdatoolkit.org/6.7.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
+                        "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Eidr"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Audience"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions"
+                    },
+                    {
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": ""
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Related Manifestations (RDA Chapter 27, Appendix J)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Has BIBFRAME Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Search works",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                                    "defaultLiteral": "two-dimensional moving image"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "remark": "http://access.rdatoolkit.org/6.10.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaultURI": "",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "Place of capture:"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Capture information",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Event"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
+                        "propertyLabel": "Event"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:Color"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Color Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:35mmFeatureFilm:SoundContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Sound Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Award (RDA 7.28)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
+                        "remark": "http://access.rdatoolkit.org/7.28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes on the Expression",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "remark": "http://access.rdatoolkit.org/6.27.3.html"
+                    }
+                ],
+                "id": "profile:bf2:35mmFeatureFilm:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-20",
+        "description": "Work, Expression, Instance for 35mmFeatureFilm",
+        "id": "profile:bf2:35mmFeatureFilm",
+        "title": "BIBFRAME 2.0 Moving Image-35mm Feature Film",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
@@ -1,0 +1,2366 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "propertyLabel": "Search works"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork",
+                        "propertyLabel": "History of the Work (RDA 6.7)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-3332.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SourceConsulted"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source Consulted",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Eidr"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifiers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Audience"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "Creator of Work (RDA 19.2)",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                                    "defaultLiteral": "two-dimensional moving image"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
+                        "propertyLabel": "Capture information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Event"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
+                        "propertyLabel": "Event"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contentAccessibility",
+                        "propertyLabel": "Accessibility Content (RDA 7.14)",
+                        "remark": "http://access.rdatoolkit.org/7.14.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Color"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent",
+                        "propertyLabel": "Sound Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Aspect"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/aspectRatio",
+                        "propertyLabel": "Aspect Ratio"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
+                        "propertyLabel": "Award (RDA 7.28)",
+                        "remark": "http://access.rdatoolkit.org/7.28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Instances"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:MIBluRayDVD:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance Of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                ""
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement",
+                        "remark": "http://access.rdatoolkit.org/2.12.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Copyright",
+                                "profile:bf2:Identifiers:UPC",
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:PubNumber",
+                                "profile:bf2:Identifiers:EAN",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local",
+                                "profile:bf2:Identifiers:Gtin14"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Credits"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Cast/Credits",
+                        "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/credits"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/v",
+                                    "defaultLiteral": "video"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/vd",
+                                    "defaultLiteral": "videodisc"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:ProdMeth"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Production Method",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Optional Language Tracks (MARC 546 Field)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Optional Subtitles"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Accessibility Content (Closed captions/ English subtitles for the deaf and hard of hearing)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contentAccessibility"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LCGFT Accessibility Term (Video recordings for ... )",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Aspect"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/aspectRatio",
+                        "propertyLabel": "Aspect Ratio"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TypeRec",
+                                "profile:bf2:RecMedium",
+                                "profile:bf2:Playback",
+                                "profile:bf2:SpecPlayback"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaultURI": "",
+                            "defaultLiteral": "",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Sound Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:BroadStd"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Video Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/videoCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:DigChar",
+                                "profile:bf2:FileType",
+                                "profile:bf2:RegEncoding",
+                                "profile:bf2:EncFmt",
+                                "profile:bf2:Resolution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "",
+                                "dataTypeURI": "",
+                                "dataTypeLabelHint": "",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Digital File Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/digitalCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Recording Equipment or System Requirements (RDA 3.20.1.3)",
+                        "remark": "http://access.rdatoolkit.org/3.20.1.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/systemRequirement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Persons, Families, Corporate Bodies Associated with the Manifestation (RDA 21.1.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp21_rda21-74.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SourceConsulted"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source Consulted",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:URL"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Administrative Metadata for Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Has Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:MIBluRayDVD:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC",
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/collection",
+                        "propertyLabel": "Collection"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Notes on the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Enumeration"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology",
+                        "propertyLabel": "Enumeration"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:ImmAcqSource"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
+                        "propertyLabel": "Immediate Source of Acquisition of Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Received date"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Summary",
+                        "remark": "http://access.rdatoolkit.org/7.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about the summary"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:Summary",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
+                "resourceLabel": "Summary note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Cast/Credits note"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:Credits",
+                "resourceLabel": "Cast/Credits note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mcolor"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ColorContent"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Color Content (RDA 7.17.1.4)",
+                        "remark": "http://access.rdatoolkit.org/7.17.1.4.html"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:Color",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ColorContent",
+                "remark": "",
+                "resourceLabel": "Color content"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maspect"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AspectRatio",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Aspect Ratio (RDA 7.19.1.4)",
+                        "remark": "http://access.rdatoolkit.org/7.19.1.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Aspect Ratio (RDA 7.19.1.4.1.4)",
+                        "remark": "http://access.rdatoolkit.org/7.19.1.4.1.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AspectRatio"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Numerical Values of Aspect Ratio (RDA 7.19.1.3)",
+                        "remark": "http://access.rdatoolkit.org/7.19.1.3.html"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:Aspect",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AspectRatio",
+                "resourceLabel": "Aspect Ratio"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "remark": "http://access.rdatoolkit.org/4.6.html",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on URL"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                "id": "profile:bf2:MIBluRayDVD:URL",
+                "resourceLabel": "URL"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Event"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date of Event"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:Event",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Event",
+                "resourceLabel": "Event"
+            },
+            {
+                "id": "profile:bf2:MIBluRayDVD:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "false",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Title information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "History of the Work (RDA 6.7)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-3332.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
+                        "remark": "http://access.rdatoolkit.org/5.8.1.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Eidr"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifiers"
+                    },
+                    {
+                        "propertyLabel": "Intended Audience",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Audience"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "true",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Classification numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Related Manifestations (RDA Chapter 27,  Appendix J)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Has BIBFRAME Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Search works",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                                    "defaultLiteral": "two-dimensional moving image"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "remark": "http://access.rdatoolkit.org/6.10.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Capture information",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Event"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
+                        "propertyLabel": "Event"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Accessibility Content (RDA 7.14)",
+                        "remark": "http://access.rdatoolkit.org/7.14.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contentAccessibility"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Color"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "propertyLabel": "Color Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:SoundContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "propertyLabel": "Sound Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MIBluRayDVD:Aspect"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Aspect Ratio",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/aspectRatio"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                ""
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Award (RDA 7.28)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
+                        "remark": "http://access.rdatoolkit.org/7.28.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Expression"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
+                        "remark": "http://access.rdatoolkit.org/6.27.3.html"
+                    }
+                ],
+                "id": "profile:bf2:MIBluRayDVD:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-20",
+        "description": "Work, Expression, Instance for BluRay DVD",
+        "id": "profile:bf2:MIBluRayDVD",
+        "title": "BIBFRAME 2.0 Moving Image-BluRay DVD",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Notated Music.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Notated Music.json
@@ -1,0 +1,2945 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup BIBFRAME works"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": [],
+                            "editable": "true",
+                            "repeatable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point Representing the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPStatement"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
+                        "propertyLabel": "Medium of Performance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/alternateMediumOfPerformance",
+                        "propertyLabel": "Alternate Declared Medium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Doubling Declared Medium",
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
+                        "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
+                        "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
+                        "remark": "http://access.rdatoolkit.org/6.16.1.3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
+                        "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-4781.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": [],
+                            "editable": "true",
+                            "repeatable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
+                                    "defaultLiteral": "Notated music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Notation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Form of Musical Notation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmusicformat"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicFormat"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicFormat",
+                        "propertyLabel": "Format of Notated Music (RDA 7.20)",
+                        "remark": "http://access.rdatoolkit.org/7.20.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Instance2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Add BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMedTest"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
+                        "propertyLabel": "Declared Medium Test"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "New BIBFRAME Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Search Existing RDA/BIBFRAME Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Agent + Preferred Title + AAP Expression Elements"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
+                                    "defaultLiteral": "Notated music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-3436.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary of Content (RDA 7.10)",
+                        "remark": "http://access.rdatoolkit.org/rdachp7_rda7-774.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPStatement"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
+                        "propertyLabel": "Declared Medium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Alternate Declared Medium",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/alternateMediumOfPerformance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:DecMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance",
+                        "propertyLabel": "Doubling Declared Medium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Notation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Form of Musical Notation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "remark": "",
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "defaultURI": "",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmusicformat"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicFormat"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicFormat",
+                        "propertyLabel": "Format of Notated Music (RDA 7.20)",
+                        "remark": "http://access.rdatoolkit.org/7.20.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": [],
+                            "editable": "true"
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Instance2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Add BIBFRAME Instance"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:Expression",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "Search Existing BIBFRAME Work and Add Expression Elements to Create New BIBFRAME Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle",
+                                "profile:bf2:Title:CollTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 2.3)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
+                        "propertyLabel": "Series Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:ISMN",
+                                "profile:bf2:Identifiers:UPC",
+                                "profile:bf2:Identifiers:Distributor",
+                                "profile:bf2:Identifiers:MusicPlate",
+                                "profile:bf2:Identifiers:MusicPub",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifiers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                                    "defaultLiteral": "unmediated"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                    "defaultLiteral": "volume"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "propertyLabel": "Extent"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial",
+                        "propertyLabel": "Applied Material (RDA 3.7)",
+                        "remark": "http://access.rdatoolkit.org/3.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mproduction"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
+                        "propertyLabel": "Production Method (RDA 3.9.1.3)",
+                        "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                        "propertyLabel": "Administrative Metadata for Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Add Item"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:Instance2",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+                "resourceLabel": "Add BIBFRAME Instance"
+            },
+            {
+                "id": "profile:bf2:NotatedMusic:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Search BIBFRAME Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "resourceTemplates": [],
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 2.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle",
+                                "profile:bf2:Title:CollTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:ISMN",
+                                "profile:bf2:Identifiers:UPC",
+                                "profile:bf2:Identifiers:Distributor",
+                                "profile:bf2:Identifiers:MusicPlate",
+                                "profile:bf2:Identifiers:MusicPub",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                                    "defaultLiteral": "unmediated"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                    "defaultLiteral": "volume"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial",
+                        "propertyLabel": "Applied Material (RDA 3.7)",
+                        "remark": "http://access.rdatoolkit.org/3.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mproduction"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
+                        "propertyLabel": "Production Method (RDA 3.9.1.3)",
+                        "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Administrative Metadata for Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "remark": ""
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:NotatedMusic:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Shelving call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmusnotation"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicNotation"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Form of Musical Notation (RDA 7.13.3)",
+                        "remark": "http://access.rdatoolkit.org/7.13.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.13.3.4.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Form of Musical Notation (RDA 7.13.3.4)"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:Notation",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicNotation",
+                "resourceLabel": "Form of Musical Notation"
+            },
+            {
+                "id": "profile:bf2:NotatedMusic:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Lookup BIBFRAME works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "true",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceCombining"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Medium of Performance (RDA 6.15)",
+                        "remark": "http://access.rdatoolkit.org/6.15.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MedPerfInst"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MedPerfVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.7.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point Representing the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Lookup",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceCombining"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance of the Musical Expression",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MedPerfInst",
+                                "profile:bf2:NotatedMusic:MedPerfVoice",
+                                "profile:bf2:NotatedMusic:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance (New)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
+                                    "defaultLiteral": "Notated music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "remark": "http://access.rdatoolkit.org/6.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:Notation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Form of Musical Notation",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "remark": "",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmusicformat"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicFormat"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Format of Notated Music (RDA 7.20)",
+                        "remark": "http://access.rdatoolkit.org/7.20.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicFormat"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Expression",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point Representing the Musical Expression (RDA 6.28.3)",
+                        "remark": "http://access.rdatoolkit.org/6.28.3.html"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Total Number of Performers: Individual Instruments (no ensemble present)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Record complete instrumentation as text field"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+                        "propertyLabel": "Total Number of Performers: Individual Instruments (ensemble present)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record complete instrumentation as text field",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Total Number of Ensembles",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:MediumOfPerformanceCombining",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
+                "resourceLabel": "Medium of Performance: Combining Facets"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search Individual Instrument or Ensemble in LCMPT ... OR ...",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Individual Instrument or Ensemble",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Number of Parts: Individual Instrument ... AND/OR ...",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Number of Performers: Individual Instrument ... AND/OR ...",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Number of Players: Percussion ... AND/OR ...",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Number of Hands: Individual instrument ... AND/OR ...",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Number of Ensembles",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search Doubling Medium of Performance ... OR ...",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Doubling Medium of Performance",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Search Alternative Instrumentation Medium of Performance ... OR ..."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Record Alternative Instrumentation Medium of Performance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Note on Instrumentation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    }
+                ],
+                "id": "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
+                "resourceLabel": "Medium of Performance: Individual Facets"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2018-02-13",
+        "description": "Work, Expression, Instance for Notated Music",
+        "id": "profile:bf2:NotatedMusic",
+        "title": "BIBFRAME 2.0 Notated Music",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Note.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Note.json
@@ -1,0 +1,199 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Contents note",
+                        "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "URI for contents"
+                    }
+                ],
+                "id": "profile:bf2:Contents",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
+                "resourceLabel": "Contents note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Note"
+                    }
+                ],
+                "id": "profile:bf2:Note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Note",
+                "resourceLabel": "Note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Script"
+                    }
+                ],
+                "id": "profile:bf2:Script",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Script",
+                "resourceLabel": "Script"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
+                        "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
+                    }
+                ],
+                "id": "profile:bf2:SourceConsulted",
+                "resourceLabel": "Source Consulted",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Source"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Summary note",
+                        "remark": "http://access.rdatoolkit.org/7.10.html"
+                    }
+                ],
+                "id": "profile:bf2:Summary",
+                "resourceLabel": "Summary note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                            }
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Supplementary Content (RDA 7.16)",
+                        "remark": "http://access.rdatoolkit.org/7.16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "URI for Supplementary Content"
+                    }
+                ],
+                "id": "profile:bf2:SupplContent",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                "resourceLabel": "Supplementary Content"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "System Requirement (RDA 3.20)",
+                        "remark": "http://access.rdatoolkit.org/3.20.html"
+                    }
+                ],
+                "id": "profile:bf2:SysReq",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/SystemRequirement",
+                "resourceLabel": "System Requirement"
+            }
+        ],
+        "id": "profile:bf2:Note",
+        "title": "BIBFRAME 2.0 Note",
+        "description": "Notes (and more) for BIBFRAME resources",
+        "date": "2017-08-21",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Place.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Place.json
@@ -1,0 +1,58 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "remark": "",
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCNAF/LCSH",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "",
+                                "remark": "http://id.loc.gov/ontologies/bibframe/Place"
+                            },
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Record Place (if it does not appear above)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    }
+                ],
+                "id": "profile:bf2:Place",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+                "resourceLabel": "Place Associated with a Work",
+                "contact": ""
+            }
+        ],
+        "id": "profile:bf2:Place",
+        "title": "BIBFRAME 2.0 Place",
+        "date": "2017-05-13",
+        "description": "Place Associated with a Resource"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
@@ -1,0 +1,426 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
+                        "propertyLabel": "Place",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:Name"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Name",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date (RDA 2.8.6)",
+                        "remark": "http://access.rdatoolkit.org/2.8.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about publisher"
+                    }
+                ],
+                "id": "profile:bf2:PublicationInformation",
+                "contact": "",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Publication",
+                "resourceLabel": "Publication Activity"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
+                        "propertyLabel": "Place",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:Name"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Name",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date (RDA 2.9.6)",
+                        "remark": "http://access.rdatoolkit.org/2.9.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Statement of Function (RDA 2.9.4.4)",
+                        "remark": "http://access.rdatoolkit.org/2.9.4.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about distributor"
+                    }
+                ],
+                "resourceLabel": "Distribution Activity",
+                "id": "profile:bf2:DistributionInformation",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Distribution"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
+                        "propertyLabel": "Place",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:Name"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Name",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date (RDA 2.10.6)",
+                        "remark": "http://access.rdatoolkit.org/2.10.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about manufacturer"
+                    }
+                ],
+                "id": "profile:bf2:ManufactureInformation",
+                "resourceLabel": "Manufacture Activity",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Manufacture"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Place (RDA 2.10.2)",
+                        "remark": "http://access.rdatoolkit.org/2.10.2.html"
+                    }
+                ],
+                "id": "profile:bf2:Provision:Place",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+                "resourceLabel": "Place"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Name (RDA 2.8.4)",
+                        "remark": "http://access.rdatoolkit.org/2.8.4.html"
+                    }
+                ],
+                "id": "profile:bf2:Provision:Name",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Agent",
+                "resourceLabel": "Name"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:PlaceTest"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
+                        "propertyLabel": "Place"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Provision:NameTest"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Name"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                        "propertyLabel": "Date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivityStatement",
+                        "propertyLabel": "Provision activity statement"
+                    }
+                ],
+                "id": "profile:bf2:PublicationInformationTest",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Publication",
+                "resourceLabel": "Publication Test"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Place"
+                    }
+                ],
+                "id": "profile:bf2:Provision:PlaceTest",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+                "resourceLabel": "Place Test"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Name"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Agent",
+                "id": "profile:bf2:Provision:NameTest",
+                "resourceLabel": "Name Test"
+            }
+        ],
+        "id": "profile:bf2:PublicationDistributionManufactureInformation",
+        "title": "BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity",
+        "description": "Publication, Distribution, Manufacture Activity",
+        "date": "2017-06-02",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 RWO.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 RWO.json
@@ -1,0 +1,932 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Affiliation"
+                            }
+                        },
+                        "propertyLabel": "Search LCNAF",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "",
+                                "dataTypeLabel": "SKOS"
+                            },
+                            "defaultURI": ""
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#Affiliation",
+                        "propertyLabel": "Input Affiliation (RDA 9.13, RDA 11.5)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Affiliation Start Date",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#affiliationStart"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#affiliationEnd",
+                        "propertyLabel": "Affiliation End Date"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:Affiliation",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Affiliation",
+                "resourceLabel": "Affiliation"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Language"
+                            }
+                        },
+                        "propertyLabel": "Language of Agent (RDA 9.14, RDA 10.8, RDA 11.8)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLanguage"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:AssociatedLanguage",
+                "resourceLabel": "Associated Language",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Language"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+                            }
+                        },
+                        "propertyLabel": "Search LCNAF",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#birthPlace"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#birthPlace",
+                        "propertyLabel": "Input Place of Birth (RDA 9.8)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5029.html"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:PlaceofBirth",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                "resourceLabel": "Associated Locale: Place of Birth"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+                            }
+                        },
+                        "propertyLabel": "Search LCNAF",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#deathPlace"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#deathPlace",
+                        "propertyLabel": "Input Place of Death (RDA 9.9)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5062.html"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:PlaceofDeath",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                "resourceLabel": "Associated Locale: Place of Death"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Country"
+                            }
+                        },
+                        "propertyLabel": "Search LCNAF",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Input Country Associated with Person (RDA 9.10)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5089.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityStartDate",
+                        "propertyLabel": "Start Date Associated with Country"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityEndDate",
+                        "propertyLabel": "End Date Associated with Country"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:Country",
+                "resourceLabel": "Associated Locale: Country",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+                            }
+                        },
+                        "propertyLabel": "Search LCNAF/LCSH",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Input Place of Residence (RDA 9.11)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5121.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Place of Residence Start Date",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityStartDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityEndDate",
+                        "propertyLabel": "Place of Residence End Date"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:PlaceOfResidence",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                "resourceLabel": "Associated Locale: Place of Residence"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+                            }
+                        },
+                        "propertyLabel": "Search Location",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Input Location of Conference, Etc. (RDA 11.3.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4164.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:LocationOfConference",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                "resourceLabel": "Associated Locale: Location of Conference"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+                            }
+                        },
+                        "propertyLabel": "Search LCNAF/LCSH",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Input Other Place Associated with Corporate Body (RDA 11.3.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4260.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Other Place Start Date",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityStartDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityEndDate",
+                        "propertyLabel": "Other Place End Date"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:OtherPlace",
+                "resourceLabel": "Associated Locale: Other Associated Place",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityStartDate",
+                        "propertyLabel": "Period of Activity Start Date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityEndDate",
+                        "propertyLabel": "Period of Activity End Date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#establishDate",
+                        "propertyLabel": "Establishment Date"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#terminateDate",
+                        "propertyLabel": "Termination Date"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:Dates",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#RWO",
+                "resourceLabel": "Dates"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity"
+                            }
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity",
+                        "propertyLabel": "Search LCSH"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity"
+                            }
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Input Field of Activity (RDA 9.15, RDA 11.10)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Field of Activity Start Date",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityStartDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityEndDate",
+                        "propertyLabel": "Field of Activity End Date"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:FieldofActivity",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#RWO",
+                "resourceLabel": "Field of Activity"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/demographicTerms",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#gender"
+                            }
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#gender",
+                        "propertyLabel": "Search LCDGT/LCSH"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Dates"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Dates Associated with Gender",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#DateNameElement"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:Gender",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#RWO",
+                "resourceLabel": "Gender"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects",
+                                "http://id.loc.gov/authorities/demographicTerms"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Occupation"
+                            }
+                        },
+                        "propertyLabel": "Search LCSH/LCDGT",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Occupation"
+                            }
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Input Profession or Occupation (RDA 9.16)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5315.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Start Date Associated with Profession or Occupation",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityStartDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#activityEndDate",
+                        "propertyLabel": "End Date Associated with Profession or Occupation"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:Occupation",
+                "resourceLabel": "Occupation",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Occupation"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#prominentFamilyMember"
+                            }
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-549.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "propertyLabel": "Prominent Member of Family (RDA 10.6)"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:ProminentFamilyMember",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#prominentFamilyMember",
+                "resourceLabel": "Prominent Family Member"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#honoraryTitle",
+                        "propertyLabel": "Honorary Title (RDA 9.4)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4631.html"
+                    }
+                ],
+                "id": "profile:bf2:Agents:RWO:HonoraryTitle",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#honoraryTitle",
+                "resourceLabel": "Honorary Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Label",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "remark": ""
+                    }
+                ],
+                "id": "profile:bf2:Agents:skosConcept",
+                "resourceLabel": "Concept",
+                "resourceURI": "http://www.w3.org/2004/02/skos/core#Concept"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Authorized Access Point for the Person (RDA 9.19)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5464.html",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Date of Birth (RDA 9.3.2) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4490.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#birthDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Date of Death (RDA 9.3.3) CORE ELEMENT",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4542.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#deathDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Dates"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Period of Activity of Person (RDA 9.3.4) CORE IF...",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4588.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#RWO"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Title of Person (RDA 9.4) CORE IF ...",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4631.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#TermsOfAddressNameElement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#honoraryTitle",
+                        "propertyLabel": "Honorary Title (RDA 9.4)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4631.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Other Designation Associated with Person (RDA 9.6) CORE IF ...",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-4980.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#entityDescriptor"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:AssociatedLanguage"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Language of Person (RDA 9.14)",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLanguage",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5213.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Gender"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Gender (RDA 9.7)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5004.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#gender"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:PlaceofBirth",
+                                "profile:bf2:Agents:RWO:PlaceofDeath",
+                                "profile:bf2:Agents:RWO:Country",
+                                "profile:bf2:Agents:RWO:PlaceOfResidence"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Associated Places for Persons (RDA 9.8 - 9.11)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5029.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Affiliation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyLabel": "Affilation (RDA 9.13)",
+                        "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5022.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasAffiliation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:FieldofActivity"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity",
+                        "propertyLabel": "Field of Activity of Person (RDA 9.15)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5242.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:RWO:Occupation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#occupation",
+                        "propertyLabel": "Profession or Occupation (RDA 9.16)",
+                        "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5315.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {}
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp10_rda10-549.html",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#prominentFamilyMember",
+                        "propertyLabel": "Prominent Member of Family (RDA 10.6)"
+                    }
+                ],
+                "id": "profile:bf2:Agent:RWO",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#RWO",
+                "resourceLabel": "Other Identifying Attributes",
+                "contact": "NDMSO"
+            }
+        ],
+        "title": "BIBFRAME 2.0 RWO",
+        "id": "profile:bf2:Agents:RWO",
+        "description": "A madsrdf:RWO is an abstract entity and identifies a Real World Object (RWO) identified by the label of a madsrdf:Authority or madsrdf:DeprecatedAuthority",
+        "contact": "NDMSO",
+        "date": "2017-05-17"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Rare Materials.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Rare Materials.json
@@ -1,0 +1,1555 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form",
+                                "profile:bf2:RareMat:RBMS",
+                                "profile:bf2:RareMat:AAT"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                    "defaultLiteral": "text"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Illus"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "propertyLabel": "Instance of"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle",
+                                "profile:bf2:Title:CollTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
+                        "propertyLabel": "Statement of responsiblity",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contributors"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
+                        "propertyLabel": "Series Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form",
+                                "profile:bf2:RareMat:RBMS"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifier for the Manifestation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:RefWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "References"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                                    "defaultLiteral": "unmediated"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                    "defaultLiteral": "volume"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "propertyLabel": "Extent",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "LCCN"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                        "propertyLabel": "Administrative Metadata for Instance"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+                "resourceLabel": "BIBFRAME Instance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "propertyLabel": "Held by"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "propertyLabel": "Location"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Agents associated with Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/custodialHistory",
+                        "propertyLabel": "Custodial History (RDA 2.18)",
+                        "remark": "http://access.rdatoolkit.org/2.18.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:ImmAcqSource"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
+                        "propertyLabel": "Immediate Source of Acquisition",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form",
+                                "profile:bf2:RareMat:RBMS"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Item"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Barcode"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC",
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Shelfmarks"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "propertyLabel": "Usage and access policy"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/collection",
+                        "propertyLabel": "Collection"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:VarTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Item Title"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item",
+                "resourceLabel": "BIBFRAME Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "propertyLabel": "RBMS term"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/genreFormSchemes/rbmscv",
+                                    "defaultLiteral": "RBMS"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source of term"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:RBMS",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                "resourceLabel": "RBMS term"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                "remark": "",
+                                "dataTypeLabelHint": ""
+                            },
+                            "valueLanguage": "",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about Illustrative Content"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:Illus",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                "resourceLabel": "Illustrative content"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Search works"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:ReferenceInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/references",
+                        "propertyLabel": "Input work title"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Location of citation"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:RefWork",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+                "resourceLabel": "References"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "https://lookup.ld4l.org/qa/search/linked_data/getty_aat_ld4l_cache"
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Getty AAT",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/GenreForm"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:AAT",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                "resourceLabel": "Getty AAT"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Monograph:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Expression of"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                    "defaultLiteral": "text"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Illus"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaultURI": "",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Expression"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    }
+                ],
+                "id": "profile:bf2:RareMat:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form",
+                                "profile:bf2:RareMat:RBMS"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Expression elements"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RareMat:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Related Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    }
+                ],
+                "id": "profile:bf2:RareMat:WorkOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)"
+            }
+        ],
+        "id": "profile:bf2:RareMat",
+        "title": "BIBFRAME 2.0 Rare Materials",
+        "description": "Work, Expression, Instance for Rare Materials",
+        "date": "2017-08-30",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Related Works and Expressions.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Related Works and Expressions.json
@@ -1,0 +1,246 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search related works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Work Authorized Access Point",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-64.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Relationship Designator for Related Work (RDA Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                        "remark": "http://access.rdatoolkit.org/rdaappj_rdaj-16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Description of Related Work"
+                    }
+                ],
+                "id": "profile:bf2:RelatedWork",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+                "resourceLabel": "Related Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search related expressions",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Related Expression Authorized Access Point",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "remark": "http://access.rdatoolkit.org/rdachp26_rda26-24.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Relationship Designator for Related Expression  (RDA Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                        "remark": "http://access.rdatoolkit.org/rdaappj_rdaj-16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Description of Related Expression"
+                    }
+                ],
+                "resourceLabel": "Related Expression",
+                "id": "profile:bf2:RelatedExpression",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Search related instances"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Related Instance Authorized Access Point"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                        "propertyLabel": "Relationship Designator for Related Instance",
+                        "remark": "http://access.rdatoolkit.org/rdaappj_rdaj-15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Description of Related Instance"
+                    }
+                ],
+                "id": "profile:bf2:RelatedInstance",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+                "resourceLabel": "Related Instance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title referenced"
+                    }
+                ],
+                "id": "profile:bf2:ReferenceInstance",
+                "resourceLabel": "Instance Referenced",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+                "remark": "used in rare materials profile"
+            }
+        ],
+        "id": "profile:bf2:RelatedWorkorExpression",
+        "title": "BIBFRAME 2.0 Related Works and Expressions",
+        "date": "2017-05-13",
+        "description": "Related Work or Expression"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Serial.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Serial.json
@@ -1,0 +1,2165 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 6.2.2, 6.2.3)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work (RDA 6.3)",
+                        "remark": "http://access.rdatoolkit.org/6.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                    "defaultLiteral": "text"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Script"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "repeatable": "false",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Related Manifestations (RDA Chapter 27,  Appendix J)",
+                        "remark": "http://access.rdatoolkit.org/rdachp27_rda27-40.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    }
+                ],
+                "id": "profile:bf2:Serial:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:Serial:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 2.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:Title:KeyTitle",
+                                "profile:bf2:Title:AbbrTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:DistributionInformation",
+                                "profile:bf2:ManufactureInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/serl",
+                                    "defaultLiteral": "serial"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Frequency"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Frequency",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/frequency"
+                    },
+                    {
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISSN",
+                                "profile:bf2:Identifiers:ISSNL",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                                    "defaultLiteral": "unmediated"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "repeatable": "true",
+                            "editable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                    "defaultLiteral": "volume"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:RelatedInstance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Instances (RDA 27.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item",
+                        "remark": "Item which is an example of the described Instance."
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                        "propertyLabel": "Administrative Metadata for Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/projectedProvisionDate",
+                        "remark": "http://id.loc.gov/ontologies/bflc.html#p_projectedProvisionDate",
+                        "propertyLabel": "Projected publication date (YYMM)"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:Serial:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Shelving call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:EnumerationAndChronology"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Enumeration And Chronology of Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:ImmAcqSource"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
+                        "propertyLabel": "Immediate Acquisition"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/acquisitionSource",
+                        "remark": "http://access.rdatoolkit.org/rdachp4_rda4-93.html",
+                        "propertyLabel": "Contact information (RDA 4.3)"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Title Proper (RDA 2.3.2)",
+                        "remark": "http://access.rdatoolkit.org/2.3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber",
+                        "propertyLabel": "Designation of Part, Section or Supplement (RDA 2.3.1.7)",
+                        "remark": "http://access.rdatoolkit.org/2.3.1.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName",
+                        "propertyLabel": "Title of Part, Section or Supplement (RDA 2.3.1.7)",
+                        "remark": "http://access.rdatoolkit.org/2.3.1.7.html"
+                    }
+                ],
+                "id": "profile:bf2:Serial:Title",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title",
+                "resourceLabel": "Title",
+                "contact": "NDMSO"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/Relationship"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search related works",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Relationship Designator for Related Work (RDA Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                        "remark": "http://access.rdatoolkit.org/rdaappj_rdaj-16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/absorbed",
+                        "propertyLabel": "Absorbed (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Continues (work):",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/continues",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuesInPart",
+                        "propertyLabel": "Continues in part (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mergerOf",
+                        "propertyLabel": "Merger of (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/separatedFrom",
+                        "propertyLabel": "Separated from (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Continued by (work):",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuedBy",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/absorbedBy",
+                        "propertyLabel": "Absorbed by (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuedInPartBy",
+                        "propertyLabel": "Continued in part by (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mergedToForm",
+                        "propertyLabel": "Merged to form (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/splitInto",
+                        "propertyLabel": "Split into (work):",
+                        "remark": "http://access.rdatoolkit.org/J.2.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplement",
+                        "propertyLabel": "Has supplement (work):"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementTo",
+                        "propertyLabel": "Supplement to (work):"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Description of Related Work"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+                "id": "profile:bf2:Serial:RelatedWork",
+                "resourceLabel": "Related Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/Relationship"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Search Related Manifestation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Record Related Manifestation Authorized Access Point",
+                        "remark": "http://access.rdatoolkit.org/27.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                        "remark": "http://access.rdatoolkit.org/J.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISSN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "ISSN of Related Manifestation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Also issued in another format as:",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
+                        "remark": "http://access.rdatoolkit.org/J.4.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
+                        "propertyLabel": "Accompanied by (manifestation):",
+                        "remark": "http://access.rdatoolkit.org/J.4.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Description of Related Manifestation"
+                    }
+                ],
+                "id": "profile:bf2:Serial:RelatedInstance",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+                "resourceLabel": "Related Instance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/firstIssue",
+                        "propertyLabel": "Numeric and/or Alphabetic Designation of First Issue or Part of Sequence (RDA 2.6.2)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-5592.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/firstIssue",
+                        "propertyLabel": "Chronological Designation of First Issue or Part of Sequence (RDA 2.6.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-5667.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/lastIssue",
+                        "propertyLabel": "Numeric and/or Alphabetic Designation of Last Issue or Part of Sequence (RDA 2.6.4)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-5759.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/lastIssue",
+                        "propertyLabel": "Chronological Designation of Last Issue or Part of Sequence (RDA 2.6.5)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-5813.html"
+                    }
+                ],
+                "id": "profile:bf2:Serial:EnumerationAndChronology",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/EnumerationAndChronology",
+                "resourceLabel": "Enumeration And Chronology"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/frequencies"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Frequency"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Frequency (RDA 2.14)",
+                        "remark": "http://access.rdatoolkit.org/2.14.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Frequency (RDA 2.17.12)",
+                        "remark": "http://access.rdatoolkit.org/2.17.12.html"
+                    }
+                ],
+                "id": "profile:bf2:Serial:Frequency",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Frequency",
+                "resourceLabel": "Frequency"
+            },
+            {
+                "id": "profile:bf2:Serial:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 6.2.2, 6.2.3)",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Form of Work (RDA 6.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.3.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.7.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Classification numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Related Expressions (RDA Chapter 26 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Expression elements"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "remark": "http://access.rdatoolkit.org/6.27.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Expression of",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                    "defaultLiteral": "text"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "remark": "http://access.rdatoolkit.org/6.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISSNL"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "ISSN-L Identifier for Expression (RDA 6.13)",
+                        "remark": "http://access.rdatoolkit.org/6.13.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Summary",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Script (RDA 7.13.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                        "remark": "http://access.rdatoolkit.org/7.13.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/millus"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                        "propertyLabel": "Illustrative Content (RDA 7.15)",
+                        "remark": "http://access.rdatoolkit.org/7.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Serial:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Color Content (RDA 7.17)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                        "remark": "http://access.rdatoolkit.org/7.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Expression",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyLabel": "Contributor (RDA 20.2)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
+                        "remark": "http://access.rdatoolkit.org/6.27.3.html"
+                    }
+                ],
+                "id": "profile:bf2:Serial:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-20",
+        "description": "Work, Expression, Instance for Serials",
+        "id": "profile:bf2:Serial",
+        "title": "BIBFRAME 2.0 Serial",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Series Information.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Series Information.json
@@ -1,0 +1,95 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement and ISSN of Series (RDA 2.12.1-2.12.8)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
+                        "remark": "http://access.rdatoolkit.org/2.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesEnumeration",
+                        "propertyLabel": "Series Numbering (RDA 2.12.9)",
+                        "remark": "http://access.rdatoolkit.org/2.12.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subseriesStatement",
+                        "propertyLabel": "Subseries Title Proper, ISSN of Subseries (RDA 2.12.10-2.12.16)",
+                        "remark": "http://access.rdatoolkit.org/2.12.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subseriesEnumeration",
+                        "propertyLabel": "Numbering within Subseries (RDA 2.12.17)",
+                        "remark": "http://access.rdatoolkit.org/2.12.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note about the series"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+                "id": "profile:bf2:SeriesInformation",
+                "resourceLabel": "Series Statement",
+                "remark": "http://access.rdatoolkit.org/rdachp2_rda2-7632.html"
+            }
+        ],
+        "id": "profile:bf2:SeriesInformation",
+        "title": "BIBFRAME 2.0 Series Information",
+        "date": "2017-06-07",
+        "contact": "NDMSO",
+        "description": "Instance, Series Information"
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Analog.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Analog.json
@@ -1,0 +1,1953 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPStatement"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:PerfMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Performed Medium",
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMedium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPInstrument"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
+                        "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
+                        "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
+                        "remark": "http://access.rdatoolkit.org/6.16.1.3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
+                        "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-4781.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                                    "defaultLiteral": "performed music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Matrix"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifiers"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
+                        "propertyLabel": "Capture information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Related Expressions",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    }
+                ],
+                "id": "profile:bf2:Analog:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:Analog:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance Of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 2.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:ManufactureInformation",
+                                "profile:bf2:DistributionInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:ISMN",
+                                "profile:bf2:Identifiers:PubNumber",
+                                "profile:bf2:Identifiers:EAN",
+                                "profile:bf2:Identifiers:UPC",
+                                "profile:bf2:TestProfile:ISRC",
+                                "profile:bf2:Identifiers:Copyright",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Credits"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Credits",
+                        "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/credits"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
+                                    "defaultLiteral": "audio"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
+                                    "defaultLiteral": "audio disc"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "",
+                                "dataTypeLabelHint": "4 3/4 in.",
+                                "remark": ""
+                            },
+                            "defaultLiteral": "",
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaultURI": "",
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "editable": "true",
+                            "defaultLiteral": "",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Applied Material (RDA 3.7)",
+                        "remark": "http://access.rdatoolkit.org/3.7.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:ProdMeth"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
+                        "propertyLabel": "Production Method",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mgeneration"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Recording Generation (RDA 3.10)",
+                        "remark": "http://access.rdatoolkit.org/3.10.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/generation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TypeRec",
+                                "profile:bf2:RecMedium",
+                                "profile:bf2:PlayingSpeed",
+                                "profile:bf2:Analog:Sound6",
+                                "profile:bf2:Playback",
+                                "profile:bf2:SpecPlayback"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": ""
+                            },
+                            "editable": "false",
+                            "defaultLiteral": "",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Sound Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic"
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Administrative Metadata for Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:Analog:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Credits note"
+                    }
+                ],
+                "id": "profile:bf2:Analog:Credits",
+                "resourceLabel": "Credits note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mgroove"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GrooveCharacteristic",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Groove Characteristic (RDA 3.16.5)",
+                        "remark": "http://access.rdatoolkit.org/3.16.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Details of Groove Characteristic (RDA 3.16.5.4)",
+                        "remark": "http://access.rdatoolkit.org/3.16.5.4.html"
+                    }
+                ],
+                "id": "profile:bf2:Analog:Sound6",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GrooveCharacteristic",
+                "resourceLabel": "Groove Characteristic"
+            },
+            {
+                "id": "profile:bf2:Analog:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "false",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceCombining"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Medium of Performance (RDA 6.15)",
+                        "remark": "http://access.rdatoolkit.org/6.15.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:MedPerfInst"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:MedPerfVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.7.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Expression of",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:MedPerfInst"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:MedPerfVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content",
+                                "dataTypeLabel": ""
+                            },
+                            "editable": "true",
+                            "remark": "",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                                    "defaultLiteral": "performed music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "remark": "http://access.rdatoolkit.org/6.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Matrix"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Identifier for the Expression",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Capture information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/vocabulary/languages"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Analog:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Expression",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Expression (RDA 6.28.3)",
+                        "remark": "http://access.rdatoolkit.org/6.28.3.html"
+                    }
+                ],
+                "id": "profile:bf2:Analog:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-10-25",
+        "description": "Work, Expression, Instance for Analog Recordings",
+        "id": "profile:bf2:Analog",
+        "title": "BIBFRAME 2.0 Sound Recording-Analog",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD-R.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD-R.json
@@ -1,0 +1,1919 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPStatement"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:PerfMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
+                        "propertyLabel": "Performed Medium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPInstrument"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
+                        "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
+                        "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
+                        "remark": "http://access.rdatoolkit.org/6.16.1.3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
+                        "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-4781.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                                    "defaultLiteral": "performed music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
+                        "propertyLabel": "Capture information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    }
+                ],
+                "id": "profile:bf2:SoundCDR:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:SoundCDR:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 2.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:ManufactureInformation",
+                                "profile:bf2:DistributionInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:ISMN",
+                                "profile:bf2:Identifiers:PubNumber",
+                                "profile:bf2:Identifiers:EAN",
+                                "profile:bf2:Identifiers:UPC",
+                                "profile:bf2:TestProfile:ISRC",
+                                "profile:bf2:Identifiers:Copyright",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Credits"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Credits",
+                        "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/credits"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
+                                    "defaultLiteral": "audio"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
+                                    "defaultLiteral": "audio disc"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "",
+                                "dataTypeLabelHint": "4 3/4 in.",
+                                "remark": ""
+                            },
+                            "defaultLiteral": "",
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaultURI": "",
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "editable": "true",
+                            "defaultLiteral": "",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Applied Material (RDA 3.7)",
+                        "remark": "http://access.rdatoolkit.org/3.7.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:ProdMeth"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
+                        "propertyLabel": "Production Method",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mgeneration"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Recording Generation (RDA 3.10)",
+                        "remark": "http://access.rdatoolkit.org/3.10.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/generation"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TypeRec",
+                                "profile:bf2:RecMedium",
+                                "profile:bf2:PlayingSpeed",
+                                "profile:bf2:Playback",
+                                "profile:bf2:SpecPlayback"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": ""
+                            },
+                            "editable": "false",
+                            "defaultLiteral": "",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Sound Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:FileType",
+                                "profile:bf2:EncFmt",
+                                "profile:bf2:FileSize"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": ""
+                            },
+                            "editable": "true",
+                            "defaultLiteral": "",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Digital Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/digitalCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SysReq"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/systemRequirement",
+                        "propertyLabel": "System Requirement"
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Administrative Metadata for Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:SoundCDR:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Credits note"
+                    }
+                ],
+                "id": "profile:bf2:SoundCDR:Credits",
+                "resourceLabel": "Credits note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
+            },
+            {
+                "id": "profile:bf2:SoundCDR:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "false",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceCombining"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Medium of Performance (RDA 6.15)",
+                        "remark": "http://access.rdatoolkit.org/6.15.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:MedPerfInst"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:MedPerfVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.7.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                        "propertyLabel": "Expression of",
+                        "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:MedPerfInst"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:MedPerfVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content",
+                                "dataTypeLabel": ""
+                            },
+                            "editable": "true",
+                            "remark": "",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                                    "defaultLiteral": "performed music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Date of Expression (RDA 6.10)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "remark": "http://access.rdatoolkit.org/6.10.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Expression (RDA 6.11)",
+                        "remark": "http://access.rdatoolkit.org/6.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Capture information",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/vocabulary/languages"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language of Content (RDA 7.12)",
+                        "remark": "http://access.rdatoolkit.org/7.12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundCDR:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Contributor (RDA 20.2)",
+                        "remark": "http://access.rdatoolkit.org/20.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Expression",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Expression (RDA 6.28.3)",
+                        "remark": "http://access.rdatoolkit.org/6.28.3.html"
+                    }
+                ],
+                "id": "profile:bf2:SoundCDR:ExpressionOld",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-09-06",
+        "description": "Work, Expression, Instance for Audio CD-R",
+        "id": "profile:bf2:SoundCDR",
+        "title": "BIBFRAME 2.0 Sound Recording-Audio CD-R",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD.json
@@ -1,0 +1,1604 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "propertyLabel": "Lookup"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "propertyLabel": "Form of Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "remark": "http://access.rdatoolkit.org/6.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "remark": "http://access.rdatoolkit.org/6.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPStatement"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
+                        "propertyLabel": "Medium of Performance Statement"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:PerfMed"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
+                        "propertyLabel": "Performed Medium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPInstrument"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:MOPEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
+                        "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
+                        "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
+                        "remark": "http://access.rdatoolkit.org/6.16.1.3.2.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
+                        "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-4781.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "propertyLabel": "(Geographic) Coverage of the Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "remark": "http://access.rdatoolkit.org/7.7.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TopicSearch",
+                                "profile:bf2:Components",
+                                "profile:bf2:TopicInput"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Summary"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                        "propertyLabel": "Summary"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/contentTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                                    "defaultLiteral": "performed music"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                        "propertyLabel": "Content Type (RDA 6.9)",
+                        "remark": "http://access.rdatoolkit.org/6.9.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Language2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                        "propertyLabel": "Language",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Capture"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
+                        "propertyLabel": "Capture information"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SupplContent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                        "propertyLabel": "Supplementary Content"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
+                        "propertyLabel": "Duration (RDA 7.22)",
+                        "remark": "http://access.rdatoolkit.org/7.22.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                        "propertyLabel": "Related Works",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedExpression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "propertyLabel": "Related Expressions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    }
+                ],
+                "id": "profile:bf2:SoundRecording:Work",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceLabel": "BIBFRAME Work"
+            },
+            {
+                "id": "profile:bf2:SoundRecording:Instance",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Instance Of",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Work"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 2.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title",
+                                "profile:bf2:Title:VarTitle",
+                                "profile:bf2:ParallelTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                        "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+                    },
+                    {
+                        "propertyLabel": "Edition Statement (RDA 2.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/2.5.html"
+                    },
+                    {
+                        "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PublicationInformation",
+                                "profile:bf2:ManufactureInformation",
+                                "profile:bf2:DistributionInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                ""
+                            ],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                        "propertyLabel": "Copyright Date (RDA 2.11)",
+                        "remark": "http://access.rdatoolkit.org/2.11.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SeriesInformation"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Series Statement",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/issuance"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                                    "defaultLiteral": "single unit"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                        "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                        "remark": "http://access.rdatoolkit.org/2.13.html"
+                    },
+                    {
+                        "propertyLabel": "Identifiers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:ISBN",
+                                "profile:bf2:Identifiers:ISMN",
+                                "profile:bf2:Identifiers:PubNumber",
+                                "profile:bf2:Identifiers:EAN",
+                                "profile:bf2:Identifiers:UPC",
+                                "profile:bf2:TestProfile:ISRC",
+                                "profile:bf2:Identifiers:Other",
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Notes about the Instance",
+                        "remark": "http://access.rdatoolkit.org/2.17.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Credits"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Credits",
+                        "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/credits"
+                    },
+                    {
+                        "propertyLabel": "Media type (RDA 3.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mediaTypes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
+                                    "defaultLiteral": "audio"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.2.html"
+                    },
+                    {
+                        "propertyLabel": "Carrier Type (RDA 3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                        "repeatable": "true",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/carriers"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
+                                    "defaultLiteral": "audio disc"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "remark": "http://access.rdatoolkit.org/3.3.html"
+                    },
+                    {
+                        "propertyLabel": "Extent",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Extent"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Dimensions (RDA 3.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabel": "",
+                                "dataTypeLabelHint": "4 3/4 in.",
+                                "remark": ""
+                            },
+                            "defaultLiteral": "",
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaultURI": "",
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "remark": "http://access.rdatoolkit.org/3.5.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+                            },
+                            "editable": "true",
+                            "defaultLiteral": "",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Base Material (RDA 3.6)",
+                        "remark": "http://access.rdatoolkit.org/3.6.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/mmaterial"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Applied Material (RDA 3.7)",
+                        "remark": "http://access.rdatoolkit.org/3.7.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:TypeRec",
+                                "profile:bf2:RecMedium",
+                                "profile:bf2:PlayingSpeed",
+                                "profile:bf2:Playback",
+                                "profile:bf2:SpecPlayback"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic",
+                        "propertyLabel": "Sound Characteristics"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:FileType",
+                                "profile:bf2:EncFmt",
+                                "profile:bf2:FileSize"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": "",
+                                "dataTypeURI": ""
+                            },
+                            "editable": "true",
+                            "defaultLiteral": "",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Digital Characteristics",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/digitalCharacteristic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SysReq"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/systemRequirement",
+                        "propertyLabel": "System Requirement"
+                    },
+                    {
+                        "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "type": "literal",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "remark": "http://access.rdatoolkit.org/4.6.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:LCCN"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "remark": "http://access.rdatoolkit.org/2.15.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Administrative Metadata for Instance",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Item"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                        "propertyLabel": "Has Item"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Instance",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+            },
+            {
+                "id": "profile:bf2:SoundRecording:Item",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Held by",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Call numbers",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Shelfmark"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Barcode",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Barcode"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Electronic location",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Held in sublocation",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Notes about the Item",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Item:Access",
+                                "profile:bf2:Item:Use",
+                                "profile:bf2:Item:Retention"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Item",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Credits note"
+                    }
+                ],
+                "id": "profile:bf2:SoundRecording:Credits",
+                "resourceLabel": "Credits note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
+            },
+            {
+                "id": "profile:bf2:SoundRecording:WorkOld",
+                "propertyTemplates": [
+                    {
+                        "propertyLabel": "Lookup",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "repeatable": "false",
+                            "useValuesFrom": [
+                                "http://mlvlp04.loc.gov:8230/resources/works"
+                            ],
+                            "valueTemplateRefs": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                            },
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bflc:Agents:PrimaryContribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creator of Work (RDA 19.2)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                        "remark": "http://access.rdatoolkit.org/19.2.html"
+                    },
+                    {
+                        "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                        "remark": "",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:WorkTitle",
+                                "profile:bf2:WorkVariantTitle",
+                                "profile:bflc:TranscribedTitle"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "propertyLabel": "Form of Work",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Date of Work (RDA 6.4)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
+                                "dataTypeLabel": "EDTF",
+                                "dataTypeLabelHint": "ISO",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.4.html",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal"
+                    },
+                    {
+                        "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Place"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/6.5.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
+                                "profile:bf2:NotatedMusic:MediumOfPerformanceCombining"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Medium of Performance (RDA 6.15)",
+                        "remark": "http://access.rdatoolkit.org/6.15.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:MedPerfInst"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
+                        "propertyLabel": "Medium of Performance - Instrument"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:MedPerfVoice"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
+                        "propertyLabel": "Medium of Performance - Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:MedPerfEnsemble"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
+                        "propertyLabel": "Medium of Performance - Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
+                        "remark": "http://access.rdatoolkit.org/6.16.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Key (RDA 6.17)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
+                        "remark": "http://access.rdatoolkit.org/6.17.html"
+                    },
+                    {
+                        "propertyLabel": "(Geographic) Coverage of the Content",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Form:Geog"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                        "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
+                        "remark": "http://access.rdatoolkit.org/7.3.html"
+                    },
+                    {
+                        "propertyLabel": "Intended Audience (RDA 7.7)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/maudience"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                            },
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/7.7.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agents:Contribution"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
+                        "remark": "http://access.rdatoolkit.org/19.3.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+                    },
+                    {
+                        "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Notes about the Work",
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:LCC",
+                                "profile:bf2:DDC"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                        "propertyLabel": "Classification numbers"
+                    },
+                    {
+                        "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:RelatedWork"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Contents"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "remark": ""
+                    },
+                    {
+                        "propertyLabel": "Expression elements",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                        "resourceTemplates": [],
+                        "type": "resource",
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Expression"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "remark": "",
+                        "mandatory": "false",
+                        "repeatable": "true"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
+                        "remark": "http://access.rdatoolkit.org/6.28.1.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                        "propertyLabel": "Your Windows ID and Comments"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:SoundRecording:Instance"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                        "propertyLabel": "Has BIBFRAME Instance"
+                    }
+                ],
+                "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
+            }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-19",
+        "description": "Work, Expression, Instance for Audio CD",
+        "id": "profile:bf2:SoundRecording",
+        "title": "BIBFRAME 2.0 Sound Recording-Audio CD",
+        "remark": ""
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Title Information.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Title Information.json
@@ -1,0 +1,685 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Title Proper (RDA 2.3.2) (BIBFRAME: Main title)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3376.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
+                        "propertyLabel": "Other Title Information (RDA 2.3.4) (BIBFRAME: Subtitle)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3782.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Part number",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Part name",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on title",
+                        "remark": "http://access.rdatoolkit.org/2.17.2.html"
+                    }
+                ],
+                "id": "profile:bf2:Title",
+                "resourceLabel": "Instance Title",
+                "remark": "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc.",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Title"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on title",
+                        "remark": "http://access.rdatoolkit.org/2.17.2.html"
+                    }
+                ],
+                "id": "profile:bflc:TranscribedTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc/TransliteratedTitle",
+                "resourceLabel": "Transliterated Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-2036.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName",
+                        "propertyLabel": "Part name"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber",
+                        "propertyLabel": "Part number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on title"
+                    }
+                ],
+                "resourceLabel": "Work Title",
+                "id": "profile:bf2:WorkTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Variant Title for Work (RDA 6.2.3, 6.14.3 (Music))",
+                        "remark": "http://access.rdatoolkit.org/rdachp6_rda6-2658.html",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on title"
+                    }
+                ],
+                "resourceLabel": "Work Title Variation",
+                "id": "profile:bf2:WorkVariantTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Note Text"
+                    }
+                ],
+                "id": "profile:bf2:Title:Note",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Note",
+                "resourceLabel": "Title note"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Variant Title (RDA 2.3.6)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-4013.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/variantType",
+                        "propertyLabel": "Variant title type"
+                    }
+                ],
+                "id": "profile:bf2:Title:VarTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
+                "resourceLabel": "Variant Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Parallel Title Proper (RDA 2.3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3695.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
+                        "propertyLabel": "Parallel Other Title Information (RDA 2.3.5)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3939.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Parallel Title",
+                        "remark": "http://access.rdatoolkit.org/2.17.2.html"
+                    }
+                ],
+                "id": "profile:bf2:ParallelTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
+                "resourceLabel": "Parallel Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Key Title"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/KeyTitle",
+                "id": "profile:bf2:Title:KeyTitle",
+                "resourceLabel": "Key Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Abbreviated Title"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle",
+                "id": "profile:bf2:Title:AbbrTitle",
+                "resourceLabel": "Abbreviated Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+                        "propertyLabel": "Collective Title"
+                    }
+                ],
+                "id": "profile:bf2:Title:CollTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/CollectiveTitle",
+                "resourceLabel": "Collective Title"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "Parallel Title Proper (RDA 2.3.3)",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3695.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
+                        "propertyLabel": "Parallel Other Title Information (RDA 2.3.5)",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3939.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/KeyTitle",
+                        "propertyLabel": "Key title"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle",
+                        "propertyLabel": "Abbreviated title"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/CollectiveTitle",
+                        "propertyLabel": "Collective title"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-4013.html",
+                        "propertyLabel": "Variant Title (RDA 2.3.6)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Title:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on title",
+                        "remark": "http://access.rdatoolkit.org/2.17.2.html"
+                    }
+                ],
+                "contact": "Title variation",
+                "resourceLabel": "Instance Title Variation",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
+                "id": "profile:bf2:VariantTitle",
+                "remark": "Title associated with the resource that is different from the Work or Instance title."
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title00MarcKey",
+                        "propertyLabel": "LC Extension: title00MarcKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title00MatchKey",
+                        "propertyLabel": "LC Extension: title00MatchKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title10MarcKey",
+                        "propertyLabel": "LC Extension: title10MarcKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title10MatchKey",
+                        "propertyLabel": "LC Extension: title10MatchKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title11MarcKey",
+                        "propertyLabel": "LC Extension: title11MarcKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title11MatchKey",
+                        "propertyLabel": "LC Extension: title11MatchKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title30MarcKey",
+                        "propertyLabel": "LC Extension: title30MarcKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title30MatchKey",
+                        "propertyLabel": "LC Extension: title30MatchKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title40MarcKey",
+                        "propertyLabel": "LC Extension: title40MarcKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/title40MatchKey",
+                        "propertyLabel": "LC Extension: title40MatchKey"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/titleSortKey",
+                        "propertyLabel": "LC Extension: titleSortKey"
+                    }
+                ],
+                "id": "profile:bf2:BflcTitle",
+                "resourceURI": "http://id.loc.gov/ontologies/bflc",
+                "resourceLabel": "Title: BIBFRAME 2.0 LC Extension"
+            }
+        ],
+        "title": "BIBFRAME 2.0 Title Information",
+        "date": "2017-05-26",
+        "contact": "NDMSO",
+        "id": "profile:bf2:Title",
+        "remark": "",
+        "description": "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc."
+    }
+}

--- a/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Topic.json
+++ b/sample_data_from_verso/data/profiles/BIBFRAME 2.0 Topic.json
@@ -1,0 +1,331 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects",
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "propertyLabel": "Search LCSH/LCNAF"
+                    }
+                ],
+                "id": "profile:bf2:TopicSearch",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Topic",
+                "resourceLabel": "Search subjects"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic:madsTopic",
+                                "profile:bf2:Topic:madsGeographic",
+                                "profile:bf2:Topic:madsTemporal",
+                                "profile:bf2:Topic:madsGenreForm"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#ComplexSubject"
+                            },
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#componentList",
+                        "propertyLabel": "Search Subject Components"
+                    }
+                ],
+                "id": "profile:bf2:Components",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Topic",
+                "resourceLabel": "Search subject components"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "propertyLabel": "Input Subject + Subdivision string"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/subjectSchemes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Source"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/subjectSchemes/lcsh",
+                                    "defaultLiteral": "LCSH"
+                                }
+                            ]
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Subject source"
+                    }
+                ],
+                "id": "profile:bf2:TopicInput",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Topic",
+                "resourceLabel": "Input subject strings"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects",
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCSH/LCNAF",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    }
+                ],
+                "id": "profile:bf2:Topic:madsTopic",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Topic",
+                "resourceLabel": "Heading or Topical subdivision"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "editable": "true",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCSH",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    }
+                ],
+                "id": "profile:bf2:Topic:madsGenreForm",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                "resourceLabel": "Form subdivision"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "true",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCSH",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    }
+                ],
+                "id": "profile:bf2:Topic:madsTemporal",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Temporal",
+                "resourceLabel": "Chronological subdivision"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "editable": "true",
+                            "repeatable": "true",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCNAF/LCSH",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "propertyLabel": "Input Geographic Term"
+                    }
+                ],
+                "id": "profile:bf2:Topic:madsGeographic",
+                "resourceURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+                "resourceLabel": "Geographic heading or subdivision"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "lookup",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/subjects",
+                                "http://id.loc.gov/authorities/names"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Search LCSH/LCNAF",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#Topic"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Topic:madsTopic",
+                                "profile:bf2:Topic:madsGeographic",
+                                "profile:bf2:Topic:madsTemporal",
+                                "profile:bf2:Topic:madsGenreForm"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": "",
+                                "dataTypeURI": ""
+                            },
+                            "editable": "true",
+                            "repeatable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#componentList",
+                        "propertyLabel": "Search Subject Components"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": ""
+                            },
+                            "repeatable": "false",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
+                        "propertyLabel": "Input Subject + Subdivision string"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/subjectSchemes"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Source"
+                            },
+                            "defaultURI": "",
+                            "repeatable": "false",
+                            "editable": "true",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Subject source"
+                    }
+                ],
+                "id": "profile:bf2:Topic",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Topic",
+                "resourceLabel": "Subject of Work"
+            }
+        ],
+        "id": "profile:bf2:Topic",
+        "title": "BIBFRAME 2.0 Topic",
+        "description": "Subject of Work",
+        "date": "2017-05-13",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/profiles/PMO Medium of Performance.json
+++ b/sample_data_from_verso/data/profiles/PMO Medium of Performance.json
@@ -1,0 +1,485 @@
+{
+    "Profile": {
+        "resourceTemplates": [
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPart2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+                        "propertyLabel": "has Medium Part"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
+                        "propertyLabel": "Total Distinct Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
+                        "propertyLabel": "Total Required Performer Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
+                        "propertyLabel": "Total Ensemble Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:DecMed",
+                "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
+                "resourceLabel": "Declared Medium of Performance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPart"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+                        "propertyLabel": "has Medium Part"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
+                        "propertyLabel": "has Distinct Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
+                        "propertyLabel": "has Ensemble Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasPerformerCount",
+                        "propertyLabel": "Performer Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:PerfMed",
+                "resourceURI": "http://performedmusicontology.org/ontology/PerformedMedium",
+                "resourceLabel": "Performed Medium"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPerfI1",
+                                "profile:bf2:PMOMedPerf:MedPerfI2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumOfPerformance",
+                        "propertyLabel": "has Medium of Performance"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:MedPart2",
+                "resourceURI": "http://performedmusicontology.org/ontology/MediumPart",
+                "resourceLabel": "Medium Part/Declared"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPerfI1",
+                                "profile:bf2:PMOMedPerf:MedPerfI2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumOfPerformance",
+                        "propertyLabel": "has Medium of Performance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
+                        "propertyLabel": "has Distinct Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
+                        "propertyLabel": "has Required Performer Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
+                        "propertyLabel": "has Ensemble Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasPerformerCount",
+                        "propertyLabel": "has Performer Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:MedPart",
+                "resourceURI": "http://performedmusicontology.org/ontology/MediumPart",
+                "resourceLabel": "Medium Part/Performed"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://performedmusicontology.org/ontology/IndividualInstrument",
+                                "remark": ""
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Individual Instrument or Voice"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
+                        "propertyLabel": "Distinct Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
+                        "propertyLabel": "Required Performer Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:MedPerfI1",
+                "resourceURI": "http://performedmusicontology.org/ontology/IndividualMediumOfPerformance",
+                "resourceLabel": "Individual Medium of Performance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://performedmusicontology.org/ontology/InstrumentEnsemble"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Ensemble"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
+                        "propertyLabel": "has Ensemble Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:MedPerfI2",
+                "resourceURI": "http://performedmusicontology.org/ontology/EnsembleMediumOfPerformance",
+                "resourceLabel": "Ensemble Medium of Performance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
+                        "propertyLabel": "has Distinct Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
+                        "propertyLabel": "has Required Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
+                        "propertyLabel": "has Ensemble Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:DecMedTotals",
+                "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
+                "resourceLabel": "Medium of Performance: Totaling Counts for the Entire Work",
+                "remark": ""
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPart2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+                        "propertyLabel": "has Medium Part"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPart2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/alternateMediumOfPerformance",
+                        "propertyLabel": "OR has Alternate Medium Part"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPart2"
+                            ],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyLabel": "OR has Doubling Medium Part",
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
+                        "propertyLabel": "Total Distinct Part Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
+                        "propertyLabel": "Total Required Performer Count"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "defaults": []
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
+                        "propertyLabel": "Total Ensemble Count"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:DecMedTest",
+                "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
+                "resourceLabel": "Declared Medium Test"
+            }
+        ],
+        "id": "profile:bf2:PMOMedPerf",
+        "title": "PMO Medium of Performance",
+        "description": "PMO Medium of Performance",
+        "date": "2018-05-24",
+        "contact": "NDMSO"
+    }
+}

--- a/sample_data_from_verso/data/vocabularies/languages.rdf
+++ b/sample_data_from_verso/data/vocabularies/languages.rdf
@@ -1,0 +1,9225 @@
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <madsrdf:MADSScheme rdf:about="http://id.loc.gov/vocabulary/languages" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#">
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/abk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Abkhaz</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Abkhaz</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ace">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Achinese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Achinese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ace</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ach">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Acoli</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Acoli</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ach</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ada">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Adangme</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Adangme</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ada</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ady">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Adygei</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Adygei</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ady</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/aar">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Afar</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afar</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aar</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/afh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Afrihili (Artificial language)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afrihili (Artificial language)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">afh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/afr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Afrikaans</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afrikaans</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">afr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ain">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ainu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ainu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ain</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/aka">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Akan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Akan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aka</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/akk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Akkadian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Akkadian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ale">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Aleut</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aleut</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ale</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/alt">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Altai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Altai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alt</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/amh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Amharic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Amharic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/anp">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Angika</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Angika</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anp</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/arg">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Aragonese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aragonese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arg</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/arc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Aramaic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aramaic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/arp">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Arapaho</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Arapaho</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arp</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/arw">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Arawak</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Arawak</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arw</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/arm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Armenian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Armenian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rup">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Aromanian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aromanian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rup</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/asm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Assamese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Assamese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ava">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Avaric</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Avaric</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ava</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ave">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Avestan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Avestan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ave</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/awa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Awadhi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Awadhi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">awa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/aym">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Aymara</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aymara</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aym</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ast">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bable</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bable</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ast</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ban">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Balinese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Balinese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ban</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Baluchi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Baluchi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bam">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bambara</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bambara</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bam</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bas">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Basa</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Basa</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bas</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bak">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bashkir</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bashkir</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bak</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/baq">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Basque</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Basque</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">baq</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bej">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Beja</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Beja</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bej</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bel">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Belarusian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Belarusian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bel</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bem">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bemba</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bemba</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bem</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bik">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bikol</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bikol</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bik</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/byn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bilin</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bilin</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">byn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bis">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bislama</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bislama</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bis</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zbl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Blissymbolics</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Blissymbolics</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zbl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bos">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bosnian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bosnian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bos</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bra">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Braj</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Braj</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bra</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bre">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Breton</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Breton</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bre</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bug">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bugis</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bugis</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bug</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bul">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bulgarian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bulgarian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bul</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bua">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Buriat</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Buriat</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bua</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bur">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Burmese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Burmese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bur</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cad">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Caddo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Caddo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cad</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/car">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Carib</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Carib</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">car</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ceb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Cebuano</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cebuano</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ceb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chg">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chagatai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chagatai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chg</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cha">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chamorro</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chamorro</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cha</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/che">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chechen</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chechen</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">che</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Cherokee</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cherokee</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chy">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Cheyenne</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cheyenne</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chy</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chibcha</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chibcha</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chinese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chinese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chinook jargon</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chinook jargon</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chp">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chipewyan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chipewyan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chp</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cho">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Choctaw</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Choctaw</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cho</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chu">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Church Slavic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Church Slavic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chu</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chuukese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chuukese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chuvash</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chuvash</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cop">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Coptic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Coptic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cop</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cor">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Cornish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cornish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cor</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cos">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Corsican</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Corsican</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cos</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cre">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Cree</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cree</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cre</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Creek</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creek</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/crh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Crimean Tatar</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Crimean Tatar</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hrv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Croatian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Croatian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hrv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cze">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Czech</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Czech</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cze</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dan">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Danish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Danish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dan</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dar">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dargwa</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dargwa</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dar</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/din">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dinka</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dinka</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">din</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/div">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Divehi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Divehi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">div</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dgr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dogrib</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dogrib</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dgr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dua">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Duala</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Duala</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dua</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dut">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dutch</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dutch</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dut</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dum">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dutch, Middle (ca. 1050-1350)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dutch, Middle (ca. 1050-1350)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dum</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dyu">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dyula</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dyula</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyu</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dzo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dzongkha</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dzongkha</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dzo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/frs">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">East Frisian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">East Frisian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frs</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bin">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Edo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Edo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bin</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/egy">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Egyptian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Egyptian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">egy</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/eka">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ekajuk</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ekajuk</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eka</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/elx">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Elamite</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Elamite</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elx</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/eng">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">English</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">English</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eng</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/enm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">English, Middle (1100-1500)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">English, Middle (1100-1500)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">enm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ang">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">English, Old (ca. 450-1100)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">English, Old (ca. 450-1100)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ang</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/myv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Erzya</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Erzya</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/epo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Esperanto</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Esperanto</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gez">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ethiopic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ethiopic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gez</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ewe">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ewe</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ewe</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ewe</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ewo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ewondo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ewondo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ewo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fan">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Fang</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fang</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fan</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Fanti</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fanti</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fao">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Faroese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Faroese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fao</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fij">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Fijian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fijian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fij</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fil">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Filipino</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Filipino</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fil</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fin">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Finnish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Finnish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fin</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fon">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Fon</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fon</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fon</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/frm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">French, Middle (ca. 1300-1600)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">French, Middle (ca. 1300-1600)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fro">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">French, Old (ca. 842-1300)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">French, Old (ca. 842-1300)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fro</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fry">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Frisian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Frisian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fry</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fur">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Friulian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Friulian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fur</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gaa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gã</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gã</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gaa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/glg">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Galician</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Galician</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glg</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lug">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ganda</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ganda</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lug</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gay">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gayo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gayo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gay</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gba">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gbaya</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gbaya</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gba</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gmh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">German, Middle High (ca. 1050-1500)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">German, Middle High (ca. 1050-1500)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gmh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/goh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">German, Old High (ca. 750-1050)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">German, Old High (ca. 750-1050)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">goh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gil">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gilbertese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gilbertese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gil</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gon">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gondi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gondi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gon</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gor">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gorontalo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gorontalo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gor</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/got">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gothic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gothic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">got</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/grb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Grebo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Grebo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gwi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gwich'in</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gwich'in</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gwi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Haida</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Haida</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Haitian French Creole</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Haitian French Creole</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hau">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hausa</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hausa</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hau</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/haw">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hawaiian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hawaiian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">haw</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/heb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hebrew</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hebrew</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hil">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hiligaynon</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hiligaynon</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hil</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hmo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hiri Motu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hiri Motu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hmo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hit">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hittite</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hittite</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hit</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hun">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hungarian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hungarian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hun</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hup">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hupa</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hupa</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hup</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/iba">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Iban</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iban</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iba</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ice">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Icelandic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Icelandic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ice</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ido">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ido</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ido</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ido</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ibo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Igbo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Igbo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ibo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ilo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Iloko</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iloko</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ilo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/smn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Inari Sami</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Inari Sami</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ind">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Indonesian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Indonesian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ind</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/inh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ingush</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ingush</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ina">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Interlingua (International Auxiliary Language Association)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Interlingua (International Auxiliary Language Association)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ina</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ile">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Interlingue</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Interlingue</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ile</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ipk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Inupiaq</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Inupiaq</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ipk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gle">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Irish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Irish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gle</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mga">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Irish, Middle (ca. 1100-1550)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Irish, Middle (ca. 1100-1550)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mga</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sga">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Irish, Old (to 1100)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Irish, Old (to 1100)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sga</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/jpn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Japanese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Japanese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jpn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/jav">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Javanese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Javanese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jav</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/jrb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Judeo-Arabic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Judeo-Arabic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jrb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kbd">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kabardian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kabardian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kbd</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kab">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kabyle</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kabyle</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kab</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kac">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kachin</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kachin</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kac</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kam">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kamba</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kamba</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kam</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kau">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kanuri</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kanuri</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kau</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kaa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kara-Kalpak</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kara-Kalpak</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kaa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/krc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Karachay-Balkar</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Karachay-Balkar</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">krc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/krl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Karelian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Karelian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">krl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kas">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kashmiri</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kashmiri</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kas</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/csb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kashubian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kashubian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">csb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kaw">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kawi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kawi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kaw</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kaz">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kazakh</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kazakh</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kaz</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kha">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Khasi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khasi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kha</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/khm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Khmer</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khmer</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">khm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kho">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Khotanese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khotanese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kho</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kik">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kikuyu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kikuyu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kik</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kmb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kimbundu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kimbundu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kmb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kin">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kinyarwanda</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kinyarwanda</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kin</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tlh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Klingon (Artificial language)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Klingon (Artificial language)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tlh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kok">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Konkani</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Konkani</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kok</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kut">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kootenai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kootenai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kut</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kor">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Korean</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Korean</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kor</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kos">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kosraean</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kosraean</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kos</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kpe">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kpelle</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kpelle</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kpe</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kua">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kuanyama</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kuanyama</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kua</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kum">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kumyk</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kumyk</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kum</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kur">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kurdish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kurdish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kur</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kru">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kurukh</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kurukh</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kru</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kir">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kyrgyz</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kyrgyz</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kir</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lam">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lamba (Zambia and Congo)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lamba (Zambia and Congo)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lam</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lao">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lao</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lao</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lao</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Latin</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Latin</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lav">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Latvian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Latvian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lav</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lez">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lezgian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lezgian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lez</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lim">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Limburgish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Limburgish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lim</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lin">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lingala</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lingala</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lin</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lit">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lithuanian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lithuanian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lit</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/jbo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lojban (Artificial language)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lojban (Artificial language)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jbo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nds">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Low German</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Low German</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nds</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dsb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lower Sorbian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lower Sorbian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/loz">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lozi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lozi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">loz</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lub">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Luba-Katanga</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luba-Katanga</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lub</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lua">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Luba-Lulua</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luba-Lulua</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lua</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lui">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Luiseño</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luiseño</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lui</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/smj">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lule Sami</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lule Sami</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smj</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lun">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lunda</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lunda</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lun</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/luo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Luo (Kenya and Tanzania)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luo (Kenya and Tanzania)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">luo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lushai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lushai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ltz">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Luxembourgish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luxembourgish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ltz</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mas">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Maasai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maasai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mas</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mac">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Macedonian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Macedonian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mac</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mad">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Madurese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Madurese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mad</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mag">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Magahi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Magahi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mag</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Maithili</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maithili</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mak">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Makasar</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Makasar</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mak</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mlt">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Maltese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maltese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mlt</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mnc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Manchu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manchu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mnc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mdr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mandar</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mandar</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mdr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/man">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mandingo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mandingo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">man</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mni">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Manipuri</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manipuri</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mni</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/glv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Manx</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manx</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/arn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mapuche</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mapuche</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mar">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Marathi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Marathi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mar</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/chm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mari</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mari</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mah">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Marshallese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Marshallese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mah</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/men">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mende</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mende</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">men</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mic">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Micmac</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Micmac</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mic</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/min">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Minangkabau</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Minangkabau</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">min</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mwl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mirandese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mirandese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mwl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/moh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mohawk</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mohawk</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">moh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mdf">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Moksha</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Moksha</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mdf</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lol">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mongo-Nkundu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mongo-Nkundu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lol</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mul">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Multiple languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Multiple languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mul</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nqo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">N'Ko</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">N'Ko</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nqo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nau">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nauru</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nauru</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nau</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nav">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Navajo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Navajo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nav</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nbl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ndebele (South Africa)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ndebele (South Africa)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nbl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nde">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ndebele (Zimbabwe)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ndebele (Zimbabwe)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nde</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ndo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ndonga</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ndonga</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ndo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nap">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Neapolitan Italian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Neapolitan Italian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nap</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nep">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nepali</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nepali</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nep</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/new">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Newari</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Newari</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">new</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nwc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Newari, Old</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Newari, Old</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nwc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nia">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nias</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nias</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nia</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/niu">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Niuean</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Niuean</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">niu</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zxx">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">No linguistic content</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">No linguistic content</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zxx</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nog">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nogai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nogai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nog</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/frr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">North Frisian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">North Frisian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sme">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Northern Sami</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Northern Sami</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sme</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nso">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Northern Sotho</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Northern Sotho</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nso</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nob">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Norwegian (Bokmål)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Norwegian (Bokmål)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nob</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nno">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Norwegian (Nynorsk)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Norwegian (Nynorsk)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nno</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nym">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nyamwezi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyamwezi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nym</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nyn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nyankole</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyankole</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nyn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nyo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nyoro</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyoro</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nyo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nzi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nzima</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nzima</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nzi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/non">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Old Norse</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Old Norse</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/peo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Old Persian (ca. 600-400 B.C.)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Old Persian (ca. 600-400 B.C.)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/osa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Osage</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Osage</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">osa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/oss">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ossetic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ossetic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oss</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Pahlavi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pahlavi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pau">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Palauan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Palauan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pau</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pli">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Pali</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pali</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pli</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pam">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Pampanga</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pampanga</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pam</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pag">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Pangasinan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pangasinan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pag</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pan">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Panjabi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Panjabi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pan</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pap">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Papiamento</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Papiamento</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pap</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pon">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Pohnpeian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pohnpeian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pon</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pol">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Polish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Polish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pol</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/por">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Portuguese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Portuguese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">por</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pro">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Provençal (to 1500)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Provençal (to 1500)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Pushto</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pushto</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/roh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Raeto-Romance</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Raeto-Romance</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">roh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rap">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Rapanui</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rapanui</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rap</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rom">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Romani</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Romani</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rom</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/run">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Rundi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rundi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">run</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Russian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Russian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sam">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Samaritan Aramaic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Samaritan Aramaic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sam</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/smi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sami</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sami</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/smo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Samoan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Samoan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sad">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sandawe</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sandawe</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sad</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sag">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sango (Ubangi Creole)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sango (Ubangi Creole)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sag</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Santali</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Santali</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/srd">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sardinian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sardinian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srd</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sas">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sasak</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sasak</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sas</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sco">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Scots</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Scots</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sco</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gla">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Scottish Gaelic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Scottish Gaelic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gla</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sel">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Selkup</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Selkup</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sel</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/srp">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Serbian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Serbian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srp</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/srr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Serer</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Serer</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/shn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Shan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Shan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/iii">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sichuan Yi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sichuan Yi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iii</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/scn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sicilian Italian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sicilian Italian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sid">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sidamo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sidamo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sid</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bla">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Siksika</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Siksika</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bla</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sin">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sinhalese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sinhalese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sin</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sms">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Skolt Sami</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Skolt Sami</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sms</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/slo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Slovak</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slovak</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/slv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Slovenian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slovenian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sog">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sogdian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sogdian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sog</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/som">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Somali</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Somali</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">som</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/snk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Soninke</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Soninke</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/wen">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sorbian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sorbian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wen</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sot">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sotho</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sotho</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sot</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sma">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Southern Sami</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Southern Sami</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sma</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/srn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sranan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sranan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/suk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sukuma</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sukuma</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sux">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sumerian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sumerian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sux</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sun">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sundanese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sundanese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sun</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Susu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Susu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ssw">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Swazi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swazi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssw</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/swe">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Swedish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swedish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swe</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gsw">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Swiss German</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swiss German</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gsw</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/syc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Syriac</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Syriac</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">syc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/syr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Syriac, Modern</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Syriac, Modern</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">syr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tgl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tagalog</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tagalog</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tgl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tah">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tahitian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tahitian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tah</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tgk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tajik</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tajik</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tgk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tmh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tamashek</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tamashek</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tmh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tam">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tamil</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tamil</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tam</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tatar</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tatar</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tel">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Telugu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Telugu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tel</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tem">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Temne</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Temne</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tem</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ter">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Terena</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Terena</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ter</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tet">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tetum</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tetum</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tet</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tha">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Thai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Thai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tha</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tig">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tigré</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tigré</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tig</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tir">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tigrinya</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tigrinya</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tir</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tiv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tiv</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tiv</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tiv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tpi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tok Pisin</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tok Pisin</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tpi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tkl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tokelauan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tokelauan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tkl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tog">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tonga (Nyasa)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tonga (Nyasa)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tog</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ton">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tongan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tongan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ton</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tsi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tsimshian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tsimshian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tsi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tso">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tsonga</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tsonga</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tso</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tsn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tswana</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tswana</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tsn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tum">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tumbuka</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tumbuka</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tum</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tur">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Turkish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Turkish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tur</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ota">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Turkish, Ottoman</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Turkish, Ottoman</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ota</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tuk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Turkmen</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Turkmen</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tuk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tvl">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tuvaluan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tuvaluan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tvl</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tyv">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tuvinian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tuvinian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tyv</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/twi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Twi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Twi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/udm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Udmurt</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Udmurt</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">udm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/uga">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ugaritic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ugaritic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uga</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/uig">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Uighur</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Uighur</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uig</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ukr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ukrainian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ukrainian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ukr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/umb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Umbundu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Umbundu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">umb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/und">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Undetermined</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Undetermined</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">und</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hsb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Upper Sorbian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Upper Sorbian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hsb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/uzb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Uzbek</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Uzbek</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uzb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/vai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Vai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Vai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ven">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Venda</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Venda</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ven</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/vie">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Vietnamese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Vietnamese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vie</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/vol">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Volapük</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Volapük</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vol</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/vot">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Votic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Votic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vot</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/wln">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Walloon</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Walloon</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wln</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/war">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Waray</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Waray</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">war</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/was">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Washoe</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Washoe</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">was</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/wel">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Welsh</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Welsh</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wel</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/wal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Wolayta</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Wolayta</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/xho">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Xhosa</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Xhosa</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xho</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sah">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Yakut</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yakut</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sah</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/yao">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Yao (Africa)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yao (Africa)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yao</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/yap">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Yapese</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yapese</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yap</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/yid">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Yiddish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yiddish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yid</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/yor">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Yoruba</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yoruba</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yor</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zap">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zapotec</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zapotec</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zap</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zza">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zaza</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zaza</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zza</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zen">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zenaga</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zenaga</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zen</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zha">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zhuang</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zhuang</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zha</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zul">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zulu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zulu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zul</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/zun">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zuni</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zuni</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zun</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/afa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Afroasiatic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afroasiatic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">afa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/alb">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Albanian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Albanian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alb</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/alg">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Algonquian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Algonquian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alg</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tut">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Altaic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Altaic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tut</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/apa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Apache languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Apache languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ara">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Arabic</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Arabic</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ara</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/art">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Artificial (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Artificial (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">art</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ath">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Athapascan (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Athapascan (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ath</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/aus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Australian languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Australian languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/map">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Austronesian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Austronesian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">map</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/aze">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Azerbaijani</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Azerbaijani</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aze</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Baltic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Baltic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bamileke languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bamileke languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bad">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Banda languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Banda languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bad</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bnt">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bantu (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bantu (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bnt</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/btk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Batak</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Batak</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">btk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ben">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bengali</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bengali</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ben</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ber">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Berber (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Berber (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ber</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bho">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bhojpuri</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bhojpuri</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bho</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/bih">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Bihari (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bihari (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bih</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cat">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Catalan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Catalan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cat</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cau">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Caucasian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Caucasian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cau</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cel">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Celtic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Celtic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cel</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Central American Indian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Central American Indian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cmc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Chamic languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chamic languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cmc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/crp">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Creoles and Pidgins (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crp</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cpe">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Creoles and Pidgins, English-based (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins, English-based (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cpe</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cpf">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Creoles and Pidgins, French-based (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins, French-based (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cpf</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cpp">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Creoles and Pidgins, Portuguese-based (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins, Portuguese-based (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cpp</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/cus">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Cushitic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cushitic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cus</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dak">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dakota</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dakota</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dak</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/day">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dayak</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dayak</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">day</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/del">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Delaware</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Delaware</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">del</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/doi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dogri</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dogri</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">doi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/dra">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Dravidian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dravidian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dra</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/efi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Efik</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Efik</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">efi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/est">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Estonian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Estonian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">est</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fiu">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Finno-Ugrian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Finno-Ugrian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fiu</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/fre">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">French</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">French</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fre</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ful">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Fula</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fula</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ful</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/geo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Georgian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Georgian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">geo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ger">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">German</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">German</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ger</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gem">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Germanic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Germanic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gem</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/grc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Greek, Ancient (to 1453)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Greek, Ancient (to 1453)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/gre">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Greek, Modern (1453- )</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Greek, Modern (1453- )</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gre</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/grn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Guarani</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Guarani</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/guj">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Gujarati</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gujarati</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">guj</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/her">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Herero</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Herero</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">her</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hin">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hindi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hindi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hin</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/hmn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Hmong</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hmong</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hmn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ijo">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ijo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ijo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ijo</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/inc">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Indic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Indic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inc</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ine">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Indo-European (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Indo-European (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ine</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/iku">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Inuktitut</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Inuktitut</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iku</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ira">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Iranian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iranian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ira</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/iro">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Iroquoian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iroquoian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iro</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ita">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Italian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Italian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ita</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/jpr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Judeo-Persian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Judeo-Persian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jpr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kalâtdlisut</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kalâtdlisut</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kan">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kannada</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kannada</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kan</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kar">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Karen languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Karen languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kar</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/khi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Khoisan (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khoisan (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">khi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kom">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Komi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Komi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kom</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kon">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kongo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kongo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kon</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kro">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Kru (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kru (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kro</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lad">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ladino</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ladino</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lad</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/lah">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Lahndā</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lahndā</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lah</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mlg">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Malagasy</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Malagasy</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mlg</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/may">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Malay</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Malay</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">may</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Malayalam</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Malayalam</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mno">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Manobo languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manobo languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mno</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mao">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Maori</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maori</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mao</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mwr">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Marwari</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Marwari</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mwr</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/myn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mayan languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mayan languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mis">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Miscellaneous languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Miscellaneous languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mis</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mkh">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mon-Khmer (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mon-Khmer (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mkh</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mon">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mongolian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mongolian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mon</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mos">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Mooré</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mooré</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mos</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/mun">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Munda (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Munda (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mun</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nah">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nahuatl</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nahuatl</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nah</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nic">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Niger-Kordofanian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Niger-Kordofanian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nic</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ssa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nilo-Saharan (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nilo-Saharan (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">North American Indian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">North American Indian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nor">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Norwegian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Norwegian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nor</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nub">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nubian languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nubian languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nub</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/nya">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Nyanja</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyanja</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nya</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/oci">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Occitan (post-1500)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Occitan (post-1500)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oci</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/xal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Oirat</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Oirat</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/oji">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Ojibwa</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ojibwa</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oji</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ori">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Oriya</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Oriya</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ori</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/orm">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Oromo</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Oromo</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orm</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/oto">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Otomian languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Otomian languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oto</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/paa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Papuan (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Papuan (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/per">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Persian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Persian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">per</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/phi">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Philippine (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Philippine (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phi</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/phn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Phoenician</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Phoenician</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/pra">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Prakrit languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Prakrit languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pra</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/que">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Quechua</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Quechua</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">que</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/raj">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Rajasthani</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rajasthani</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">raj</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rar">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Rarotongan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rarotongan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rar</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/roa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Romance (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Romance (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">roa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rum">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Romanian</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Romanian</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rum</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sal">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Salishan languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Salishan languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sal</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/san">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sanskrit</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sanskrit</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">san</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sem">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Semitic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Semitic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sem</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sna">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Shona</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Shona</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sna</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sgn">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sign languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sign languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sgn</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/snd">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sindhi</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sindhi</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snd</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sit">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Sino-Tibetan (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sino-Tibetan (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sit</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sio">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Siouan (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Siouan (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sio</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/den">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Slavey</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slavey</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">den</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sla">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Slavic (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slavic (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sla</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/son">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Songhai</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Songhai</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">son</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/sai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">South American Indian (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">South American Indian (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/spa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Spanish</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Spanish</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/swa">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Swahili</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swahili</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swa</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tai">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tai (Other)</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tai (Other)</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tai</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tib">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tibetan</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tibetan</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tib</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tli">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tlingit</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tlingit</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tli</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/tup">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Tupi languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tupi languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tup</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/urd">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Urdu</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Urdu</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">urd</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/wak">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Wakashan languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Wakashan languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wak</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/him">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Western Pahari languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Western Pahari languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">him</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/wol">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Wolof</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Wolof</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wol</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ypk">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Yupik languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yupik languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ypk</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <madsrdf:hasTopMemberOfMADSScheme>
+      <madsrdf:Language rdf:about="http://id.loc.gov/vocabulary/languages/znd">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource"/>
+	<rdf:type rdf:resource="http://id.loc.gov/vocabulary/languages/MARC_Language"/>
+	<madsrdf:authoritativeLabel xml:lang="en">Zande languages</madsrdf:authoritativeLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zande languages</rdfs:label>
+	<madsrdf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">znd</madsrdf:code>
+      </madsrdf:Language>
+    </madsrdf:hasTopMemberOfMADSScheme>
+    <rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">MARC List for Languages</rdfs:label>
+    <rdfs:comment xml:lang="en" rdf:parseType="Literal" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+      <xhtml:div class="schemeAbout" title="About MARC Languages:" property="rdfs:comment" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+        <xhtml:p> MARC List for Languages provides three-character lowercase alphabetic strings that serve as the identifiers of languages and language groups. The codes are usually based on the first three letters of the English form or, in some cases, vernacular form of the corresponding language name. The codes are varied where necessary to resolve conflicts and are not intended to be abbreviations of a language name. When the name of a language is changed in the list, the original code is generally retained. </xhtml:p>
+        <xhtml:p> The codes in this list are equivalent to those of ISO 639-2 (Bibliographic) codes and some codes from ISO 639-5, although the language name labels may differ. They are linked to the equivalent codes in ISO 639-2 and ISO 639-5 and the corresponding two-character codes in ISO 639-1. </xhtml:p>
+        <xhtml:p> The list contains over 480 discrete codes.  It is also searchable at: <xhtml:a href="http://www.loc.gov/marc/languages/langhome.html">MARC Code List for Languages</xhtml:a>. </xhtml:p>
+      </xhtml:div>
+    </rdfs:comment>
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  <madsrdf:adminMetadata>
+      <ri:RecordInfo xmlns:ri="http://id.loc.gov/ontologies/RecordInfo#">
+        <ri:recordStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">modified</ri:recordStatus>
+        <ri:recordChangeDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-04-26T00:00:00</ri:recordChangeDate>
+        <ri:recordContentSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      </ri:RecordInfo>
+    </madsrdf:adminMetadata>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/abk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Abkhaz</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Abkhaz</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ace">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Achinese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Achinese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ace</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ach">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Acoli</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Acoli</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ach</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ada">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Adangme</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Adangme</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ada</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ady">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Adygei</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Adygei</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ady</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/aar">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Afar</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afar</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aar</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/afh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Afrihili (Artificial language)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afrihili (Artificial language)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">afh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/afr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Afrikaans</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afrikaans</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">afr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ain">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ainu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ainu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ain</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/aka">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Akan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Akan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aka</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/akk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Akkadian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Akkadian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ale">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aleut</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aleut</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ale</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/alt">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Altai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Altai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alt</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/amh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Amharic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Amharic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/anp">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Angika</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Angika</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anp</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/arg">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aragonese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aragonese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arg</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/arc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aramaic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aramaic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/arp">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Arapaho</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Arapaho</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arp</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/arw">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Arawak</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Arawak</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arw</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/arm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Armenian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Armenian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/rup">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aromanian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aromanian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rup</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/asm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Assamese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Assamese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ava">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Avaric</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Avaric</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ava</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ave">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Avestan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Avestan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ave</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/awa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Awadhi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Awadhi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">awa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/aym">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aymara</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Aymara</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aym</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ast">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bable</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bable</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ast</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ban">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Balinese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Balinese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ban</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Baluchi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Baluchi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bam">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bambara</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bambara</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bam</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bas">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Basa</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Basa</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bas</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bak">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bashkir</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bashkir</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bak</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/baq">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Basque</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Basque</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">baq</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bej">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Beja</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Beja</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bej</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bel">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Belarusian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Belarusian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bel</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bem">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bemba</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bemba</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bem</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bik">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bikol</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bikol</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bik</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/byn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bilin</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bilin</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">byn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bis">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bislama</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bislama</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bis</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zbl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Blissymbolics</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Blissymbolics</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zbl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bos">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bosnian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bosnian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bos</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bra">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Braj</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Braj</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bra</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bre">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Breton</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Breton</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bre</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bug">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bugis</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bugis</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bug</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bul">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bulgarian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bulgarian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bul</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bua">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Buriat</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Buriat</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bua</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bur">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Burmese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Burmese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bur</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cad">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Caddo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Caddo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cad</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/car">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Carib</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Carib</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">car</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ceb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cebuano</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cebuano</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ceb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chg">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chagatai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chagatai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chg</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cha">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chamorro</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chamorro</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cha</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/che">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chechen</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chechen</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">che</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cherokee</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cherokee</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chy">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cheyenne</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cheyenne</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chy</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chibcha</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chibcha</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chinese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chinese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chinook jargon</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chinook jargon</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chp">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chipewyan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chipewyan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chp</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cho">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Choctaw</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Choctaw</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cho</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chu">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Church Slavic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Church Slavic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chu</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chuukese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chuukese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chuvash</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chuvash</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cop">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Coptic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Coptic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cop</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cor">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cornish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cornish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cor</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cos">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Corsican</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Corsican</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cos</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cre">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cree</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cree</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cre</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Creek</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creek</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/crh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Crimean Tatar</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Crimean Tatar</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hrv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Croatian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Croatian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hrv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cze">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Czech</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Czech</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cze</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dan">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Danish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Danish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dan</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dar">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dargwa</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dargwa</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dar</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/din">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dinka</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dinka</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">din</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/div">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Divehi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Divehi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">div</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dgr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dogrib</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dogrib</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dgr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dua">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Duala</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Duala</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dua</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dut">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dutch</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dut</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dum">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dutch, Middle (ca. 1050-1350)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dutch, Middle (ca. 1050-1350)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dum</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dyu">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dyula</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dyula</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyu</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dzo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dzongkha</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dzongkha</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dzo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/frs">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Frisian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">East Frisian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frs</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bin">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Edo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Edo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bin</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/egy">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Egyptian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Egyptian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">egy</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/eka">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ekajuk</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ekajuk</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eka</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/elx">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Elamite</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Elamite</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elx</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/eng">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">English</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">English</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eng</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/enm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">English, Middle (1100-1500)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">English, Middle (1100-1500)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">enm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ang">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">English, Old (ca. 450-1100)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">English, Old (ca. 450-1100)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ang</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/myv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Erzya</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Erzya</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/epo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Esperanto</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Esperanto</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gez">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ethiopic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ethiopic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gez</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ewe">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ewe</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ewe</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ewe</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ewo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ewondo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ewondo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ewo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fan">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fang</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fang</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fan</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fanti</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fanti</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fao">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Faroese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Faroese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fao</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fij">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fijian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fijian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fij</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fil">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Filipino</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Filipino</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fil</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fin">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Finnish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Finnish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fin</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fon">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fon</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fon</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fon</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/frm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">French, Middle (ca. 1300-1600)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">French, Middle (ca. 1300-1600)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fro">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">French, Old (ca. 842-1300)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">French, Old (ca. 842-1300)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fro</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fry">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Frisian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Frisian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fry</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fur">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Friulian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Friulian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fur</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gaa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gã</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gã</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gaa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/glg">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Galician</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Galician</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glg</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lug">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ganda</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ganda</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lug</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gay">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gayo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gayo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gay</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gba">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gbaya</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gbaya</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gba</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gmh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">German, Middle High (ca. 1050-1500)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">German, Middle High (ca. 1050-1500)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gmh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/goh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">German, Old High (ca. 750-1050)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">German, Old High (ca. 750-1050)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">goh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gil">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gilbertese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gilbertese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gil</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gon">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gondi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gondi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gon</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gor">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gorontalo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gorontalo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gor</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/got">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gothic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gothic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">got</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/grb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Grebo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Grebo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gwi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gwich'in</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gwich'in</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gwi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Haida</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Haida</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Haitian French Creole</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Haitian French Creole</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hau">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hausa</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hausa</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hau</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/haw">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hawaiian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hawaiian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">haw</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/heb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hebrew</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hebrew</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hil">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hiligaynon</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hiligaynon</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hil</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hmo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hiri Motu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hiri Motu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hmo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hit">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hittite</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hittite</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hit</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hun">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hungarian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hungarian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hun</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hup">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hupa</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hupa</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hup</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/iba">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iban</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iban</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iba</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ice">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Icelandic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Icelandic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ice</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ido">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ido</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ido</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ido</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ibo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Igbo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Igbo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ibo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ilo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iloko</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iloko</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ilo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/smn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Inari Sami</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Inari Sami</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ind">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Indonesian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Indonesian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ind</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/inh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ingush</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ingush</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ina">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Interlingua (International Auxiliary Language Association)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Interlingua (International Auxiliary Language Association)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ina</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ile">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Interlingue</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Interlingue</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ile</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ipk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Inupiaq</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Inupiaq</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ipk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gle">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Irish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Irish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gle</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mga">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Irish, Middle (ca. 1100-1550)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Irish, Middle (ca. 1100-1550)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mga</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sga">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Irish, Old (to 1100)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Irish, Old (to 1100)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sga</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/jpn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Japanese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Japanese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jpn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/jav">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Javanese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Javanese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jav</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/jrb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Judeo-Arabic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Judeo-Arabic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jrb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kbd">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kabardian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kabardian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kbd</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kab">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kabyle</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kabyle</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kab</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kac">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kachin</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kachin</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kac</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kam">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kamba</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kamba</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kam</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kau">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kanuri</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kanuri</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kau</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kaa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kara-Kalpak</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kara-Kalpak</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kaa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/krc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Karachay-Balkar</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Karachay-Balkar</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">krc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/krl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Karelian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Karelian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">krl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kas">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kashmiri</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kashmiri</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kas</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/csb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kashubian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kashubian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">csb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kaw">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kawi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kawi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kaw</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kaz">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kazakh</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kazakh</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kaz</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kha">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Khasi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khasi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kha</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/khm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Khmer</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khmer</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">khm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kho">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Khotanese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khotanese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kho</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kik">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kikuyu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kikuyu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kik</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kmb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kimbundu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kimbundu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kmb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kin">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kinyarwanda</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kinyarwanda</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kin</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tlh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Klingon (Artificial language)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Klingon (Artificial language)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tlh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kok">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Konkani</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Konkani</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kok</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kut">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kootenai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kootenai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kut</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kor">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Korean</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Korean</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kor</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kos">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kosraean</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kosraean</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kos</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kpe">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kpelle</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kpelle</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kpe</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kua">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kuanyama</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kuanyama</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kua</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kum">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kumyk</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kumyk</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kum</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kur">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kurdish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kurdish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kur</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kru">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kurukh</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kurukh</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kru</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kir">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kyrgyz</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kyrgyz</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kir</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lam">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lamba (Zambia and Congo)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lamba (Zambia and Congo)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lam</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lao">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lao</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lao</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lao</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Latin</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Latin</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lav">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Latvian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Latvian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lav</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lez">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lezgian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lezgian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lez</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lim">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Limburgish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Limburgish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lim</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lin">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lingala</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lingala</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lin</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lit">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lithuanian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lithuanian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lit</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/jbo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lojban (Artificial language)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lojban (Artificial language)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jbo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nds">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Low German</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Low German</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nds</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dsb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lower Sorbian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lower Sorbian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/loz">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lozi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lozi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">loz</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lub">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Luba-Katanga</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luba-Katanga</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lub</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lua">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Luba-Lulua</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luba-Lulua</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lua</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lui">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Luiseño</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luiseño</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lui</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/smj">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lule Sami</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lule Sami</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smj</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lun">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lunda</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lunda</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lun</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/luo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Luo (Kenya and Tanzania)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luo (Kenya and Tanzania)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">luo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lushai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lushai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ltz">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Luxembourgish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Luxembourgish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ltz</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mas">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maasai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maasai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mas</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mac">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Macedonian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Macedonian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mac</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mad">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Madurese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Madurese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mad</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mag">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Magahi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Magahi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mag</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maithili</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maithili</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mak">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Makasar</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Makasar</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mak</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mlt">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maltese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maltese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mlt</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mnc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Manchu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manchu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mnc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mdr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mandar</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mandar</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mdr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/man">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mandingo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mandingo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">man</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mni">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Manipuri</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manipuri</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mni</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/glv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Manx</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manx</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/arn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mapuche</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mapuche</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mar">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Marathi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Marathi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mar</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/chm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mari</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mari</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mah">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Marshallese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Marshallese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mah</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/men">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mende</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mende</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">men</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mic">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Micmac</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Micmac</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mic</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/min">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Minangkabau</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Minangkabau</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">min</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mwl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mirandese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mirandese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mwl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/moh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mohawk</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mohawk</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">moh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mdf">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Moksha</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Moksha</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mdf</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lol">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mongo-Nkundu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mongo-Nkundu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lol</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mul">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Multiple languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Multiple languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mul</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nqo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">N'Ko</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">N'Ko</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nqo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nau">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nauru</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nauru</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nau</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nav">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Navajo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Navajo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nav</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nbl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ndebele (South Africa)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ndebele (South Africa)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nbl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nde">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ndebele (Zimbabwe)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ndebele (Zimbabwe)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nde</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ndo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ndonga</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ndonga</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ndo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nap">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Neapolitan Italian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Neapolitan Italian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nap</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nep">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nepali</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nepali</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nep</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/new">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Newari</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Newari</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">new</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nwc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Newari, Old</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Newari, Old</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nwc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nia">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nias</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nias</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nia</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/niu">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Niuean</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Niuean</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">niu</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zxx">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">No linguistic content</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">No linguistic content</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zxx</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nog">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nogai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nogai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nog</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/frr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">North Frisian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">North Frisian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sme">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Northern Sami</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Northern Sami</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sme</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nso">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Northern Sotho</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Northern Sotho</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nso</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nob">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Norwegian (Bokmål)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Norwegian (Bokmål)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nob</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nno">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Norwegian (Nynorsk)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Norwegian (Nynorsk)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nno</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nym">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nyamwezi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyamwezi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nym</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nyn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nyankole</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyankole</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nyn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nyo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nyoro</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyoro</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nyo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nzi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nzima</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nzima</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nzi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/non">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Old Norse</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Old Norse</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/peo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Old Persian (ca. 600-400 B.C.)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Old Persian (ca. 600-400 B.C.)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/osa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Osage</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Osage</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">osa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/oss">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ossetic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ossetic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oss</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pahlavi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pahlavi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pau">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Palauan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Palauan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pau</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pli">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pali</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pali</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pli</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pam">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pampanga</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pampanga</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pam</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pag">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pangasinan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pangasinan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pag</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pan">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Panjabi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Panjabi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pan</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pap">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Papiamento</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Papiamento</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pap</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pon">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pohnpeian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pohnpeian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pon</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pol">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Polish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Polish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pol</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/por">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Portuguese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Portuguese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">por</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pro">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Provençal (to 1500)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Provençal (to 1500)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pushto</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Pushto</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/roh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Raeto-Romance</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Raeto-Romance</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">roh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/rap">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rapanui</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rapanui</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rap</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/rom">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Romani</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Romani</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rom</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/run">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rundi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rundi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">run</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/rus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Russian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Russian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sam">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Samaritan Aramaic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Samaritan Aramaic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sam</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/smi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sami</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sami</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/smo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Samoan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Samoan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sad">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sandawe</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sandawe</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sad</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sag">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sango (Ubangi Creole)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sango (Ubangi Creole)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sag</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Santali</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Santali</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/srd">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sardinian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sardinian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srd</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sas">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sasak</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sasak</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sas</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sco">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Scots</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Scots</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sco</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gla">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Scottish Gaelic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Scottish Gaelic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gla</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sel">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Selkup</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Selkup</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sel</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/srp">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Serbian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Serbian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srp</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/srr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Serer</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Serer</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/shn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Shan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Shan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/iii">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sichuan Yi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sichuan Yi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iii</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/scn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sicilian Italian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sicilian Italian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sid">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sidamo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sidamo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sid</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bla">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Siksika</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Siksika</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bla</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sin">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sinhalese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sinhalese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sin</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sms">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Skolt Sami</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Skolt Sami</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sms</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/slo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Slovak</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slovak</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/slv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Slovenian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slovenian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sog">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sogdian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sogdian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sog</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/som">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Somali</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Somali</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">som</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/snk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Soninke</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Soninke</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/wen">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sorbian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sorbian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wen</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sot">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sotho</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sotho</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sot</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sma">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern Sami</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Southern Sami</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sma</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/srn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sranan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sranan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/suk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sukuma</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sukuma</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sux">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sumerian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sumerian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sux</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sun">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sundanese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sundanese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sun</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Susu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Susu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ssw">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Swazi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swazi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssw</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/swe">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Swedish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swedish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swe</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gsw">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Swiss German</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swiss German</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gsw</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/syc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Syriac</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Syriac</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">syc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/syr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Syriac, Modern</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Syriac, Modern</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">syr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tgl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tagalog</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tagalog</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tgl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tah">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tahitian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tahitian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tah</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tgk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tajik</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tajik</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tgk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tmh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tamashek</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tamashek</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tmh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tam">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tamil</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tamil</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tam</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tatar</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tatar</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tel">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Telugu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Telugu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tel</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tem">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Temne</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Temne</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tem</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ter">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Terena</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Terena</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ter</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tet">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tetum</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tetum</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tet</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tha">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Thai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Thai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tha</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tig">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tigré</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tigré</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tig</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tir">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tigrinya</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tigrinya</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tir</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tiv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tiv</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tiv</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tiv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tpi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tok Pisin</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tok Pisin</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tpi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tkl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tokelauan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tokelauan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tkl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tog">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tonga (Nyasa)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tonga (Nyasa)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tog</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ton">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tongan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tongan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ton</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tsi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tsimshian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tsimshian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tsi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tso">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tsonga</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tsonga</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tso</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tsn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tswana</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tswana</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tsn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tum">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tumbuka</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tumbuka</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tum</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tur">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Turkish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Turkish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tur</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ota">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Turkish, Ottoman</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Turkish, Ottoman</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ota</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tuk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Turkmen</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Turkmen</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tuk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tvl">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tuvaluan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tuvaluan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tvl</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tyv">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tuvinian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tuvinian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tyv</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/twi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Twi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Twi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/udm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Udmurt</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Udmurt</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">udm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/uga">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ugaritic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ugaritic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uga</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/uig">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Uighur</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Uighur</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uig</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ukr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ukrainian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ukrainian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ukr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/umb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Umbundu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Umbundu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">umb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/und">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Undetermined</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Undetermined</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">und</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hsb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Upper Sorbian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Upper Sorbian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hsb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/uzb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Uzbek</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Uzbek</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uzb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/vai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Vai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Vai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ven">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Venda</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Venda</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ven</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/vie">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Vietnamese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Vietnamese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vie</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/vol">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Volapük</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Volapük</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vol</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/vot">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Votic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Votic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vot</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/wln">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Walloon</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Walloon</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wln</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/war">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Waray</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Waray</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">war</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/was">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Washoe</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Washoe</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">was</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/wel">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Welsh</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Welsh</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wel</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/wal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wolayta</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Wolayta</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/xho">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Xhosa</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Xhosa</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xho</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sah">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yakut</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yakut</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sah</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/yao">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yao (Africa)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yao (Africa)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yao</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/yap">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yapese</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yapese</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yap</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/yid">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yiddish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yiddish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yid</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/yor">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yoruba</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yoruba</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yor</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zap">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zapotec</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zapotec</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zap</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zza">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zaza</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zaza</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zza</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zen">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zenaga</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zenaga</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zen</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zha">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zhuang</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zhuang</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zha</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zul">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zulu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zulu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zul</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/zun">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zuni</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zuni</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zun</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/afa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Afroasiatic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Afroasiatic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">afa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/alb">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Albanian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Albanian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alb</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/alg">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Algonquian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Algonquian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alg</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tut">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Altaic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Altaic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tut</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/apa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Apache languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Apache languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ara">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Arabic</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Arabic</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ara</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/art">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Artificial (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Artificial (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">art</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ath">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Athapascan (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Athapascan (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ath</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/aus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Australian languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Australian languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/map">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Austronesian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Austronesian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">map</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/aze">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Azerbaijani</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Azerbaijani</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aze</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Baltic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Baltic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bamileke languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bamileke languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bad">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Banda languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Banda languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bad</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bnt">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bantu (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bantu (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bnt</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/btk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Batak</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Batak</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">btk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ben">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bengali</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bengali</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ben</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ber">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Berber (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Berber (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ber</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bho">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bhojpuri</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bhojpuri</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bho</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/bih">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bihari (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Bihari (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bih</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cat">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Catalan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Catalan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cat</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cau">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Caucasian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Caucasian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cau</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cel">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Celtic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Celtic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cel</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Central American Indian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Central American Indian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cmc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chamic languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Chamic languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cmc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/crp">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Creoles and Pidgins (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crp</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cpe">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Creoles and Pidgins, English-based (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins, English-based (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cpe</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cpf">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Creoles and Pidgins, French-based (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins, French-based (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cpf</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cpp">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Creoles and Pidgins, Portuguese-based (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Creoles and Pidgins, Portuguese-based (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cpp</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/cus">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cushitic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Cushitic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cus</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dak">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dakota</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dakota</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dak</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/day">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dayak</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dayak</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">day</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/del">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Delaware</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Delaware</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">del</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/doi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dogri</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dogri</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">doi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/dra">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Dravidian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Dravidian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dra</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/efi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Efik</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Efik</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">efi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/est">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Estonian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Estonian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">est</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fiu">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Finno-Ugrian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Finno-Ugrian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fiu</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/fre">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">French</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">French</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fre</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ful">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fula</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Fula</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ful</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/geo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Georgian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Georgian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">geo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ger">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">German</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">German</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ger</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gem">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Germanic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Germanic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gem</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/grc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Greek, Ancient (to 1453)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Greek, Ancient (to 1453)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/gre">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Greek, Modern (1453- )</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Greek, Modern (1453- )</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gre</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/grn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Guarani</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Guarani</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/guj">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Gujarati</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Gujarati</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">guj</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/her">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Herero</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Herero</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">her</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hin">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hindi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hindi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hin</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/hmn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hmong</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Hmong</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hmn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ijo">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ijo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ijo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ijo</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/inc">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Indic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Indic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inc</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ine">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Indo-European (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Indo-European (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ine</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/iku">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Inuktitut</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Inuktitut</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iku</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ira">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iranian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iranian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ira</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/iro">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iroquoian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Iroquoian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iro</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ita">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Italian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Italian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ita</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/jpr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Judeo-Persian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Judeo-Persian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jpr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kalâtdlisut</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kalâtdlisut</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kan">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kannada</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kannada</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kan</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kar">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Karen languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Karen languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kar</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/khi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Khoisan (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Khoisan (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">khi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kom">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Komi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Komi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kom</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kon">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kongo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kongo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kon</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/kro">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kru (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Kru (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kro</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lad">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ladino</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ladino</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lad</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/lah">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lahndā</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Lahndā</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lah</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mlg">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Malagasy</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Malagasy</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mlg</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/may">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Malay</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Malay</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">may</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Malayalam</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Malayalam</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mno">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Manobo languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Manobo languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mno</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mao">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maori</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Maori</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mao</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mwr">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Marwari</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Marwari</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mwr</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/myn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mayan languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mayan languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mis">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Miscellaneous languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Miscellaneous languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mis</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mkh">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mon-Khmer (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mon-Khmer (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mkh</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mon">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mongolian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mongolian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mon</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mos">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mooré</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Mooré</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mos</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/mun">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Munda (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Munda (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mun</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nah">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nahuatl</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nahuatl</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nah</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nic">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Niger-Kordofanian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Niger-Kordofanian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nic</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ssa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nilo-Saharan (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nilo-Saharan (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">North American Indian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">North American Indian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nor">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Norwegian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Norwegian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nor</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nub">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nubian languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nubian languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nub</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/nya">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nyanja</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Nyanja</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nya</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/oci">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Occitan (post-1500)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Occitan (post-1500)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oci</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/xal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Oirat</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Oirat</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/oji">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ojibwa</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Ojibwa</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oji</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ori">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Oriya</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Oriya</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ori</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/orm">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Oromo</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Oromo</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orm</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/oto">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Otomian languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Otomian languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oto</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/paa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Papuan (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Papuan (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/per">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Persian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Persian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">per</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/phi">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Philippine (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Philippine (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phi</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/phn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Phoenician</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Phoenician</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/pra">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Prakrit languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Prakrit languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pra</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/que">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Quechua</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Quechua</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">que</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/raj">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rajasthani</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rajasthani</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">raj</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/rar">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rarotongan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Rarotongan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rar</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/roa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Romance (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Romance (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">roa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/rum">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Romanian</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Romanian</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rum</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sal">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Salishan languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Salishan languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sal</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/san">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sanskrit</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sanskrit</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">san</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sem">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Semitic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Semitic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sem</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sna">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Shona</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Shona</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sna</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sgn">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sign languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sign languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sgn</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/snd">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sindhi</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sindhi</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snd</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sit">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sino-Tibetan (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Sino-Tibetan (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sit</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sio">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Siouan (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Siouan (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sio</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/den">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Slavey</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slavey</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">den</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sla">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Slavic (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Slavic (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sla</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/son">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Songhai</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Songhai</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">son</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/sai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">South American Indian (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">South American Indian (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/spa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Spanish</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Spanish</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/swa">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Swahili</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Swahili</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swa</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tai">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tai (Other)</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tai (Other)</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tai</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tib">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tibetan</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tibetan</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tib</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tli">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tlingit</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tlingit</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tli</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/tup">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tupi languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Tupi languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tup</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/urd">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Urdu</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Urdu</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">urd</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/wak">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wakashan languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Wakashan languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wak</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/him">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Western Pahari languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Western Pahari languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">him</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/wol">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wolof</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Wolof</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wol</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/ypk">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yupik languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Yupik languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ypk</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:hasTopConcept xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <rdf:Description rdf:about="http://id.loc.gov/vocabulary/languages/znd">
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Zande languages</skos:prefLabel>
+	<rdfs:label xml:lang="en" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Zande languages</rdfs:label>
+	<skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">znd</skos:notation>
+      </rdf:Description>
+    </skos:hasTopConcept>
+    <skos:changeNote xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+      <cs:ChangeSet xmlns:cs="http://purl.org/vocab/changeset/schema#">
+	<cs:subjectOfChange rdf:resource="http://id.loc.gov/vocabulary/languages"/>
+	<cs:creatorName rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+	<cs:createdDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-04-26T00:00:00</cs:createdDate>
+	<cs:changeReason rdf:datatype="http://www.w3.org/2001/XMLSchema#string">modified</cs:changeReason>
+      </cs:ChangeSet>
+    </skos:changeNote>
+  </madsrdf:MADSScheme>
+</rdf:RDF>


### PR DESCRIPTION
Adds sample profiles and languages to a sample_data_from_verso directory that are tracked as normal git resources. This reduces the build size of our production docker containers and should allow the current Circle-CI to build working images on Dockerhub. 

Fixes #118