### PR TITLE
Add update_ecs job to Circle build, based on TACO and rialto-derivatives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,30 @@ jobs:
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push ld4p/sinopia_profile_editor:latest
 
+  update_ecs:
+    working_directory: ~/sinopia_profile_editor
+    docker: # NOT the default
+      - image: circleci/python:3.7-stretch-node-browsers
+    steps:
+      - run: sudo pip install awscli
+      - run:
+          name: Update AWS ECS
+          command: |
+            mkdir ~/.aws
+            echo -e "[circle]\naws_access_key_id=$CIRCLE_ACCESS_KEY_ID\naws_secret_access_key=$CIRCLE_SECRET_KEY\n" > ~/.aws/credentials
+            unset AWS_SESSION_TOKEN
+            aws configure set region us-west-2
+            aws configure set output json
+            temp_creds=$(aws sts assume-role --role-session-name DevelopersRole --role-arn $DEV_ROLE_ARN --profile circle | jq .Credentials)
+            export AWS_ACCESS_KEY_ID=$(echo "$temp_creds" | jq .AccessKeyId | xargs)
+            export AWS_SECRET_ACCESS_KEY=$(echo "$temp_creds" | jq .SecretAccessKey | xargs)
+            export AWS_SESSION_TOKEN=$(echo "$temp_creds" | jq .SessionToken | xargs)
+            aws configure list # Show confirmation of config
+            task_arn=$(aws ecs list-task-definitions --family-prefix sinopia-pe --region us-west-2 --sort DESC --max-items 1 | jq --raw-output --exit-status '.taskDefinitionArns[]')
+            cluster_arn=$(aws ecs list-clusters --region us-west-2 | jq --raw-output --exit-status '.clusterArns[] | select(contains(":cluster/sinopia-dev"))')
+            # echo -n "task_arn=$task_arn\ncluster_arn=$cluster_arn\n"
+            aws ecs update-service --service sinopia-pe --region us-west-2 --cluster $cluster_arn --task-definition $task_arn --force-new-deployment
+
 workflows:
   version: 2
   build:
@@ -90,3 +114,6 @@ workflows:
             branches:
               only:
                 - master
+      - update_ecs:
+          requires:
+            - register_image


### PR DESCRIPTION
Here's a build that completed and apparently updated the actual ECS container:
https://circleci.com/gh/LD4P/sinopia_profile_editor/530?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Note, because this job has nothing to do with the code (which is separately posted to docker hub) and only concerns itself with AWS commands, it uses an entirely different docker base image so that Python (and `jq` among other tools) is already installed!

You can review that CI output for effect.  I then added the workflow relationship so that deployment only happens after successful `register_image` (i.e. only after merged to `master`).