### PR TITLE
load ontologies via versoSpoof

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,15 +10,52 @@ app.use(express.static('source'));
 app.use(express.static('node_modules'));
 
 const versoSpoof = require('./source/versoSpoof.js')
-app.all("/verso*", function (req, res) {
+
+app.all("/verso*", function (req, res, next) {
   if (req.query.filter.where.configType === 'profile') {
     res.json(versoSpoof.profiles)
+  } else if (req.query.filter.where.configType === 'ontology') {
+    res.json(versoSpoof.ontologies)
   } else if (req.query.filter.where.configType === 'vocabulary') {
     res.json(versoSpoof.vocabularies)
   } else {
     res.send(`Verso not enabled -- app made request ${req}`)
   }
+  next()
 })
+
+const ontologyUrls = []
+loadOntologyUrls()
+app.all("/server/whichrt", function (req, res) {
+  const reqUri = req.query.uri
+  if (reqUri != null) {
+    // console.debug(`DEBUG: got server/whichrt for ${reqUri}.`)
+    if (ontologyUrls.includes(reqUri)) {
+      // FIXME:  there's probably a better way to find the value in array forEach, but there are only 5 urls
+      var oxml
+      versoSpoof.owlOntUrlToXmlMappings.forEach( function(el) {
+        if (reqUri == el.url) {
+          oxml = el.xml
+        }
+      })
+      res.status(200).type('xml').send(oxml)
+    } else {
+      // other spots using whichRT are checkURI validations for resourceURI and propertyURI
+      console.error(`server/whichrt called for uri other than ontology ${reqUri}`)
+      res.status(400).send(`server/whichrt called for uri other than ontology ${reqUri}`)
+    }
+  } else {
+    console.error(`server/whichrt called without uri ${req}`)
+    res.status(400).send(`server/whichrt called without uri ${req}`)
+  }
+})
+
+function loadOntologyUrls() {
+  versoSpoof.ontologies.forEach(function (el) {
+    ontologyUrls.push(el.json.url)
+  })
+}
+
 // app.listen(port, host);
 app.listen(port);
 

--- a/source/__tests__/integration/create-ontologies.test.js
+++ b/source/__tests__/integration/create-ontologies.test.js
@@ -18,6 +18,32 @@ describe('Create profile has ontologies available for resource template', () => 
     const modalTitleSel = `${modalSel} > div.modal-header > h3.modal-title`
     await expect_value_in_sel_textContent(modalTitleSel, 'Choose Vocab Template')
   })
+
+  describe('ontologies select', () => {
+    const modalBodySel = `${modalSel} > div.modal-body`
+    const selectVocabSel = `${modalBodySel} > div#select_box_holder > select[name="chooseVocab"]`
+
+    beforeAll(() => {
+      page
+        .waitForSelector(selectVocabSel)
+        .catch(error => console.log(`promise error for ontologies selector: ${error}`))
+    })
+
+    it('populated with ontologies (via versoSpoof)', async () => {
+      await expect_value_in_sel_textContent(`${selectVocabSel} > option:nth-child(2)`, 'BFLC')
+      await expect_value_in_sel_textContent(`${selectVocabSel} > option:nth-child(3)`, 'RDF')
+      await expect_value_in_sel_textContent(`${selectVocabSel} > option:nth-child(4)`, 'RDFS')
+      await expect_value_in_sel_textContent(`${selectVocabSel} > option:nth-child(5)`, 'MADSRDF')
+      await expect_value_in_sel_textContent(`${selectVocabSel} > option:nth-child(6)`, 'Bibframe 2.0')
+    })
+
+    it('ontologies selectable', async () => {
+      await expect(page).toSelect(selectVocabSel, 'RDF')
+
+      const resourcePickSel = `${modalBodySel} > select#resourcePick`
+      await expect_value_in_sel_textContent(`${resourcePickSel} > option:nth-child(1)`, 'Property')
+    })
+  })
 })
 
 async function expect_value_in_sel_textContent(sel, value) {

--- a/source/__tests__/integration/create-ontologies.test.js
+++ b/source/__tests__/integration/create-ontologies.test.js
@@ -1,0 +1,27 @@
+describe('Create profile has ontologies available for resource template', () => {
+  const modalSel = 'div#chooseResource > div.modal-dialog > div.modal-content'
+  beforeAll(async () => {
+    // page.on('console', msg => console.log('PAGE LOG:', msg.text()))
+    await page.goto('http://127.0.0.1:8000/#/profile/create/')
+    page
+      .waitForSelector('a#addResource')
+      .then(async () => await page.click('a#addResource'))
+      .catch(error => console.log(`promise error for addResource link: ${error}`))
+    page
+      .waitForSelector('a#resourceChoose')
+      .then(async () => await page.click('a#resourceChoose'))
+      .catch(error => console.log(`promise error for select resource link: ${error}`))
+    await page.waitForSelector(modalSel)
+  })
+
+  it('modal title says Choose Vocab Template', async () => {
+    const modalTitleSel = `${modalSel} > div.modal-header > h3.modal-title`
+    await expect_value_in_sel_textContent(modalTitleSel, 'Choose Vocab Template')
+  })
+})
+
+async function expect_value_in_sel_textContent(sel, value) {
+  await page.waitForSelector(sel)
+  const sel_text = await page.$eval(sel, e => e.textContent)
+  expect(sel_text).toBe(value)
+}

--- a/source/__tests__/versoSpoof.test.js
+++ b/source/__tests__/versoSpoof.test.js
@@ -1,18 +1,18 @@
 describe('spoofed verso', () => {
-  let verso_spoof  = require('../../source/versoSpoof.js')
+  let versoSpoof  = require('../../source/versoSpoof.js')
 
   describe('profiles', () => {
     it('array of length 30', () => {
-      expect(verso_spoof.profiles).toHaveLength(30)
+      expect(versoSpoof.profiles).toHaveLength(30)
     })
     it('profile has id', () => {
-      expect(verso_spoof.profiles[0]['id']).toBe('profile:bf2:AdminMetadata')
+      expect(versoSpoof.profiles[0]['id']).toBe('profile:bf2:AdminMetadata')
     })
     it('profile has name', () => {
-      expect(verso_spoof.profiles[0]['name']).toBe('Metadata for BIBFRAME Resources')
+      expect(versoSpoof.profiles[0]['name']).toBe('Metadata for BIBFRAME Resources')
     })
     it('profile has type', () => {
-      verso_spoof.profiles.forEach(p => {
+      versoSpoof.profiles.forEach(p => {
         expect(p['configType']).toBe('profile')
       })
     })
@@ -20,16 +20,45 @@ describe('spoofed verso', () => {
 
   describe('vocabularies', () => {
     it('array of length 1', () => {
-      expect(verso_spoof.vocabularies).toHaveLength(1)
+      expect(versoSpoof.vocabularies).toHaveLength(1)
     })
     it('vocabulary has name', () => {
-      expect(verso_spoof.vocabularies[0]['name']).toBe('Languages')
+      expect(versoSpoof.vocabularies[0]['name']).toBe('Languages')
     })
     it('vocabulary has type', () => {
-      expect(verso_spoof.vocabularies[0]['configType']).toBe('vocabulary')
+      expect(versoSpoof.vocabularies[0]['configType']).toBe('vocabulary')
     })
     it('vocabulary has no id', () => {
-      expect(verso_spoof.vocabularies[0]['id']).toBeUndefined()
+      expect(versoSpoof.vocabularies[0]['id']).toBeUndefined()
+    })
+  })
+
+  describe('ontologies', () => {
+    it('array of length 5', () => {
+      expect(versoSpoof.ontologies).toHaveLength(5)
+    })
+    it('ontology has id', () => {
+      expect(versoSpoof.ontologies[0]['id']).toBe('Bibframe-ontology')
+    })
+    it('ontology has name', () => {
+      expect(versoSpoof.ontologies[0]['name']).toBe('Bibframe-ontology')
+    })
+    it('ontology has type', () => {
+      versoSpoof.ontologies.forEach(ont => {
+        expect(ont['configType']).toBe('ontology')
+      })
+    })
+  })
+
+  describe('owlOntUrlToXmlMappings', () => {
+    it('array of length 5', () => {
+      expect(versoSpoof.owlOntUrlToXmlMappings).toHaveLength(5)
+    })
+    it('mapping has url', () => {
+      expect(versoSpoof.owlOntUrlToXmlMappings[0]['url']).toBe('http://id.loc.gov/ontologies/bibframe.rdf')
+    })
+    it('mapping has xml', () => {
+      expect(versoSpoof.owlOntUrlToXmlMappings[0]['xml']).toBeDefined()
     })
   })
 })

--- a/source/assets/js/modules/profile/services/vocab.service.js
+++ b/source/assets/js/modules/profile/services/vocab.service.js
@@ -14,7 +14,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
     var vocabResourceData = [];
     var vocabPropertyData = [];
     var vocabDatatypeData = [];
-    
+
     var languageList = [];
 
     // Takes in the rdf JSON object and puts a list of resources
@@ -76,7 +76,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
             data.comment = (rdfProperties.comment != null) ? rdfProperties.comment.__text.toString() : "";
             data.uri = rdfProperties["_rdf:about"];
             propertyData.push(data);
-            
+
             return propertyData;
         }
 
@@ -149,7 +149,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
     // Method that will set the vocab data for each list.
     var _setVocabData = function(name, url, properties, resources, datatypes) {
         var item = $q.defer();
-        
+
         Server.get(url,{},false)
         .then(function(response) {
             // if a vocab file is empty then we will pass over it and return.
@@ -223,7 +223,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
     vocab.setVocabData = function() {
         // if the local storage has expired, gather the data and set it up again
         // TODO: make this connect to the real RDF
-        
+
         // const vurl = '/verso/api/configs?filter[where][configType]=vocabulary&filter[fields][name]=true&filter[fields][id]=true&filter[where][name][neq]=Languages';
         const vurl = '/verso/api/configs?filter[where][configType]=ontology';
 
@@ -237,7 +237,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
 
             // loop through the list of vocabs and gather up the data.
             angular.forEach(response, function(value) {
-                var url = 'server/whichrt?uri=' + value.json.url;
+               var url = 'server/whichrt?uri=' + value.json.url;
 
                 // test that we hvae a key and this isn't a comment.
                 if(value.id != null) {
@@ -272,11 +272,13 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
         var currDate = new Date(lsDate);
         var beginDate = new Date();
         var endDate = new Date();
-        
+
         beginDate.setDate(beginDate.getDate() - 7);
         endDate.setDate(endDate.getDate() + 7);
-        
-        if(!lsDate || !(currDate >= beginDate && currDate <= endDate)) {
+
+        // Sinopia: we want to load vocabs if they aren't already in localStorageService
+        // if(!lsDate || !(currDate >= beginDate && currDate <= endDate)) {
+        if(!lsDate) {
             localStorageService.clearAll();
             vocab.setVocabData();
             localStorageService.set('date', (new Date()).toDateString());
@@ -285,6 +287,13 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
             vocabResourceData = localStorageService.get("resourceReference");
             vocabPropertyData = localStorageService.get("propertyReference");
             vocabDatatypeData = localStorageService.get("datatypeReference");
+            if (vocabResourceData == null ||
+                vocabPropertyData == null ||
+                vocabDatatypeData == null) {
+                localStorageService.clearAll();
+                vocab.setVocabData();
+                localStorageService.set('date', (new Date()).toDateString());
+            }
         }
     };
 
@@ -328,10 +337,10 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
 
         return vocabDatatypeData;
     };
-    
+
     vocab.getLanguages = function() {
         var queue = $q.defer();
-        
+
         if(languageList.length > 0) {
             queue.resolve(languageList);
         }
@@ -369,9 +378,9 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
                 queue.resolve(languageList);
             });
         }
-        
+
         return queue.promise;
-        
+
     };
 
     fillResource = function(vocab) {

--- a/source/assets/rdfxml/bflc.rdf.xml
+++ b/source/assets/rdfxml/bflc.rdf.xml
@@ -1,0 +1,279 @@
+<!-- from http://id.loc.gov/ontologies/bflc.rdf 2018-10-29 -->
+<rdf:RDF xml:base="http://id.loc.gov/ontologies/bflc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:bf="http://id.loc.gov/ontologies/bibframe/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcterms="http://purl.org/dc/terms/">
+  <owl:Ontology rdf:about="">
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017-05-04T15:04:44.622-04:00</owl:versionInfo>
+    <rdfs:label>BIBFRAME vocabulary with LC extensions</rdfs:label>
+    <dcterms:modified>2017-05-04T15:04:44.622-04:00</dcterms:modified>
+    <owl:imports rdf:resource="http://id.loc.gov/vocabulary/relators"/>
+    <owl:imports rdf:resource="http://id.loc.gov/ontologies/bibframe"/>
+  </owl:Ontology>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/AppliesTo">
+    <rdfs:label>Applies to</rdfs:label>
+    <skos:definition>The component of a resource to which a charactreristic applies</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/EncodingLevel">
+    <rdfs:label>Encoding level</rdfs:label>
+    <skos:definition>Designation of the fullness of the bibliographic description.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/MetadataLicensor">
+    <rdfs:label>Metadata licensor</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Organization that licenses the intellectual property rights to the data contained in the description.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/PrimaryContribution">
+    <rdfs:label>Primary contribution</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Contribution"/>
+    <skos:definition>Contribution for which the agent is the name chosen as the name part of the name and title access point.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/Relation">
+    <rdfs:label>Relation</rdfs:label>
+    <skos:definition>Connection between resources.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/Relationship">
+    <rdfs:label>Relationship</rdfs:label>
+    <skos:definition>Resource and its connection to another resource.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/DemographicGroup">
+    <rdfs:label>Demographic group</rdfs:label>
+    <skos:definition>Characteristics of a group of agents.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/CreatorCharacteristic">
+    <rdfs:label>Creator characteristic</rdfs:label>
+    <skos:definition>Category to which the creators of the resource belong.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/MachineModel">
+    <rdfs:label>Model</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SystemRequirement"/>
+    <skos:definition>Model of the computing device on which the resource operates.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/ProgrammingLanguage">
+    <rdfs:label>Programming language</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SystemRequirement"/>
+    <skos:definition>Name of the programming language associated with the data comprising the resource.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/OperatingSystem">
+    <rdfs:label>Operating system</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SystemRequirement"/>
+    <skos:definition>Software that directly operates a system's hardware and serves as a platform for applications.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bflc/ImageBitDepth">
+    <rdfs:label>Image bit depth</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>The number of bits used to represent each pixel in an image.</skos:definition>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/demographicGroup">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/DemographicGroup"/>
+    <skos:definition>Characteristics of a group of agents.</skos:definition>
+    <rdfs:comment>Domain? : </rdfs:comment>
+    <rdfs:label>Demographic group</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/creatorCharacteristic">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/CreatorCharacteristic"/>
+    <skos:definition>Category to which the creators of the resource belong.</skos:definition>
+    <rdfs:comment>Domain? : </rdfs:comment>
+    <rdfs:label>Creator characteristic</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/projectedProvisionDate">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/date"/>
+    <skos:definition>Projected date of publication of the resource.</skos:definition>
+    <rdfs:comment>Domain? : </rdfs:comment>
+    <rdfs:label>Projected publication date</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/metadataLicensor">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bflc/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/MetadataLicensor"/>
+    <skos:definition>Organization that licenses the intellectual property rights to the data contained in the description.</skos:definition>
+    <rdfs:label>Metadata licensor</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/encodingLevel">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bflc/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/EncodingLevel"/>
+    <skos:definition>Designation of the fullness of the bibliographic description.</skos:definition>
+    <rdfs:label>Encoding level</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/appliesTo">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/AppliesTo"/>
+    <skos:definition>The component of a resource to which a charactreristic applies.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Applies to</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/applicableInstitution">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Institutional location of a resource to which a particular piece of description applies.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Applicable institution</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/relationship">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/Relationship"/>
+    <skos:definition>Resource and its connection to another resource.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Related resource and relationship</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bflc/relation">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bflc/Relation"/>
+    <skos:definition>Connection between resources.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Specific relationship</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/name00MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Match key for X00 Name</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/name10MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Match key for X10 Name</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/name11MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Match key for X11 Name</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/name00MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for personal name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>MARC key for X00 Names</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/name10MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>MARC key for X10 Names</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/name11MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>MARC key for X11 Names</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/primaryContributorName00MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for entry name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Primay X00 Name Match key</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/primaryContributorName10MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for entry name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Primay X10 Name Match key</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/primaryContributorName11MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for entry name matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Primay X11 Name Match key</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title00MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Match key for Title X00</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title10MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Match key for Title X10</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title11MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Match key for Title X11</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title30MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title30MatchKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title40MatchKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title40MatchKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title00MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title00MarcKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title10MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title10MarcKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title11MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title11MarcKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title30MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title30MarcKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/title40MarcKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for title matching.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>title40MarcKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bflc/titleSortKey">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String for sorting.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>titleSortKey</rdfs:label>
+    <dcterms:modified>2017-02-02 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+</rdf:RDF>

--- a/source/assets/rdfxml/bibframe.rdf.xml
+++ b/source/assets/rdfxml/bibframe.rdf.xml
@@ -1,0 +1,2603 @@
+<!-- from http://id.loc.gov/ontologies/bibframe.rdf 2018-10-29 -->
+<rdf:RDF xml:base="http://id.loc.gov/ontologies/bibframe/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:bf="http://id.loc.gov/ontologies/bibframe/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcterms="http://purl.org/dc/terms/">
+  <owl:Ontology rdf:about="">
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017-05-04T14:49:12.796-04:00</owl:versionInfo>
+    <rdfs:label>BIBFRAME vocabulary</rdfs:label>
+    <dcterms:modified>2017-05-04T14:49:12.796-04:00</dcterms:modified>
+  </owl:Ontology>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Work">
+    <rdfs:label>Work</rdfs:label>
+    <skos:definition>Resource reflecting a conceptual essence of a cataloging resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Instance">
+    <rdfs:label>Instance</rdfs:label>
+    <skos:definition>Resource reflecting an individual, material embodiment of a Work.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Item">
+    <rdfs:label>Item</rdfs:label>
+    <skos:definition>Single example of an Instance.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Text">
+    <rdfs:label>Text</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Resource intended to be perceived visually and understood through the use of language in written or spoken form.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Cartography">
+    <rdfs:label>Cartography</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Resource that shows spatial information, including maps, atlases, globes, digital, and other cartographic resources.</skos:definition>
+    <dcterms:modified>2016-04-25 (fixed typo in definition)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Audio">
+    <rdfs:label>Audio</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Resources expressed in an audible form, including music or other sounds.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/NotatedMusic">
+    <rdfs:label>Notated music</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Graphic, non-realized representations of musical works intended to be perceived visually.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/NotatedMovement">
+    <rdfs:label>Notated movement</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Graphic, non-realized representations of movement intended to be perceived visually, e.g. dance.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Dataset">
+    <rdfs:label>Dataset</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Data encoded in a defined structure. Includes numeric data, environmental data,etc., used by applications software to calculate averages, correlations, etc., or to produce models, etc., but not normally displayed in its raw form.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/StillImage">
+    <rdfs:label>Still image</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Resource expressed through line, shape, shading, etc., intended to be perceived visually as a still image or images in two dimensions. Includes two-dimensional images and slides and transparencies.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MovingImage">
+    <rdfs:label>Moving image</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Images intended to be perceived as moving, including motion pictures (using liveaction and/or animation), video recordings of performances, events,etc.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-26 (fixed typo in definition)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Object">
+    <rdfs:label>Three-dimensional object</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Resource in a form intended to be perceived visually in three-dimensions. Includes man-made objects such as models, sculptures, clothing, and toys, as well as naturally occurring objects such as specimens mounted for viewing.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Multimedia">
+    <rdfs:label>Software or multimedia</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Electronic resource that is a computer program (i.e., digitally encoded instructions intended to be processed and performed by a computer) or which consists of multiple media types that are software driven, such as videogames.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MixedMaterial">
+    <rdfs:label>Mixed material</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Resource comprised of multiple types which are not driven by software. This may include materials in two or more forms that are related by virtue of their having been accumulated by or about a person or body., archival fonds.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Print">
+    <rdfs:label>Printed</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is printed.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Manuscript">
+    <rdfs:label>Manuscript</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is written in handwriting or typescript. These are generally unique resources.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Archival">
+    <rdfs:label>Archival controlled</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resources organically created, accumulated, and/or used by a person, family, or organization in the course of conduct of affairs and preserved because of their continuing value.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Tactile">
+    <rdfs:label>Tactile material</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is intended to be perceived by touch.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Collection">
+    <rdfs:label>Collection</rdfs:label>
+    <skos:definition>Aggregation of resources, generally gathered together artificially.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Electronic">
+    <rdfs:label>Electronic</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is intended for manipulation by a computer, accessed either directly or remotely.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Note">
+    <rdfs:label>Note</rdfs:label>
+    <skos:definition>Information, usually in textual form, on attributes of a resource or some aspect of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Identifier">
+    <rdfs:label>Identifier</rdfs:label>
+    <skos:definition>Token or name that is associated with a resource, such as a URI or an ISBN.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Unit">
+    <rdfs:label>Unit</rdfs:label>
+    <skos:definition>Units in which a value is expressed.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Role">
+    <rdfs:label>Role</rdfs:label>
+    <skos:definition>Function played or provided by a contributor, e.g., author, illustrator, etc.</skos:definition>
+    <dcterms:modified>2017-02-03 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Source">
+    <rdfs:label>Source</rdfs:label>
+    <skos:definition>Resource from which value or label came or was derived.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Status">
+    <rdfs:label>Status</rdfs:label>
+    <skos:definition>Designation of the validity or position of something, e.g., whether something is incorrect or available.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Agent">
+    <rdfs:label>Agent</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <skos:definition>Entity having a role in a resource, such as a person or organization.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-05-13 (New subclass)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Person">
+    <rdfs:label>Person</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Individual or identity established by an individual (either alone or in collaboration with one or more other individuals).</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Family">
+    <rdfs:label>Family</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Two or more persons related by birth, marriage, adoption, civil union, or similar legal status, or who otherwise present themselves as a family.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Organization">
+    <rdfs:label>Organization</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Corporation or group of persons and/or organizations that acts, or may act, as a unit.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Jurisdiction">
+    <rdfs:label>Jurisdiction</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Legal or political unit administering a geographic area.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Meeting">
+    <rdfs:label>Meeting</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Gathering of individuals or representatives of various bodies for the purpose of discussing and/or acting on topics of common interest.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Topic">
+    <rdfs:label>Topic</rdfs:label>
+    <skos:definition>Concept or area of knowledge.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Temporal">
+    <rdfs:label>Temporal concept</rdfs:label>
+    <skos:definition>Chronological period.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Place">
+    <rdfs:label>Place</rdfs:label>
+    <skos:definition>Geographic location.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Event">
+    <rdfs:label>Event entity</rdfs:label>
+    <skos:definition>Something that happens at a certain time and location, such as a performance, speech, or athletic event, that is documented by a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Contribution">
+    <rdfs:label>Contribution</rdfs:label>
+    <skos:definition>Agent and role with respect to the resource being described.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Content">
+    <rdfs:label>Content type</rdfs:label>
+    <skos:definition>Categorization reflecting the fundamental form of communication in which the content is expressed and the human sense through which it is intended to be perceived.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Media">
+    <rdfs:label>Media type</rdfs:label>
+    <skos:definition>Categorization reflecting the general type of intermediation device required to view, play, run, etc., the content of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Carrier">
+    <rdfs:label>Carrier type</rdfs:label>
+    <skos:definition>Categorization reflecting the format of the storage medium and housing of a carrier.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/GenreForm">
+    <rdfs:label>Genre/form</rdfs:label>
+    <skos:definition>Characteristics of works with similar plots, themes, settings, etc. (e.g., westerns, thrillers), or with a particular format of purpose (e.g., animation, short), or a combination (e.g., horror film where horror is the genre and film is the form).</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Title">
+    <rdfs:label>Title entity</rdfs:label>
+    <skos:definition>Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Definition changed)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/VariantTitle">
+    <rdfs:label>Title variation</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
+    <skos:definition>Title associated with the resource that is different from the Work or Instance title.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/KeyTitle">
+    <rdfs:label>Key title</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/VariantTitle"/>
+    <skos:definition>Unique title for a continuing resource that is assigned by the ISSN International Center in conjunction with an ISSN.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle">
+    <rdfs:label>Abbreviated title</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/VariantTitle"/>
+    <skos:definition>Title as abbreviated for citation, indexing, and/or identification.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ParallelTitle">
+    <rdfs:label>Parallel title proper</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/VariantTitle"/>
+    <skos:definition>Title in another language and/or script.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/CollectiveTitle">
+    <rdfs:label>Collective title</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/VariantTitle"/>
+    <skos:definition>Title for a compilation of resources.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Language">
+    <rdfs:label>Language entity</rdfs:label>
+    <skos:definition>Language entity.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicMedium">
+    <rdfs:label>Music medium information</rdfs:label>
+    <skos:definition>Summary statement of the medium for a musical work.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicInstrument">
+    <rdfs:label>Musical instrument</rdfs:label>
+    <skos:definition>Instrument for which a musical work is appropriate.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicEnsemble">
+    <rdfs:label>Music ensemble</rdfs:label>
+    <skos:definition>Ensemble for which a musical work is appropriate.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicVoice">
+    <rdfs:label>Music voice</rdfs:label>
+    <skos:definition>Voice for which a musical work is appropriate.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/GeographicCoverage">
+    <rdfs:label>Geographic coverage</rdfs:label>
+    <skos:definition>Geographic coverage of the content of the resource.</skos:definition>
+    <dcterms:modified>2017-02-06 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/IntendedAudience">
+    <rdfs:label>Intended audience information</rdfs:label>
+    <skos:definition>Information that identifies the specific intended or target audience or intellectual level for which the content described is considered appropriate. Also used to record interest and motivation levels and special learner characteristics.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Arrangement">
+    <rdfs:label>Organization of materials information</rdfs:label>
+    <skos:definition>Information about the organization and arrangement of a collection of items. For instance, for computer files, organization and arrangement information may be the file structure and sort sequence of a file; for visual materials, this information may be how a collection is arranged.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Dissertation">
+    <rdfs:label>Dissertation information</rdfs:label>
+    <skos:definition>Information about a work presented as part of the formal requirements for an academic degree.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Summary">
+    <rdfs:label>Summary</rdfs:label>
+    <skos:definition>Description of the content of a resource, such as an abstract, summary, etc..</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Capture">
+    <rdfs:label>Capture of content</rdfs:label>
+    <skos:definition>Information about place and date associated with the capture (i.e., recording, filming, etc.) of the content of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Notation">
+    <rdfs:label>Notation</rdfs:label>
+    <skos:definition>Information on the alphabet, script, or symbol system used to convey the content of the resource, including specialized scripts, typefaces, tactile notation, movement notation, and musical notation.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ContentAccessibility">
+    <rdfs:label>Content accessibility information</rdfs:label>
+    <skos:definition>Information that assists those with a sensory impairment for greater understanding of content, e.g., captions.</skos:definition>
+    <dcterms:modified>2017-02-07 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Script">
+    <rdfs:label>Script used</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Notation"/>
+    <skos:definition>Information on the script, or symbol system used to convey the content of a text resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicNotation">
+    <rdfs:label>Music notation used</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Notation"/>
+    <skos:definition>Information on the symbol system used to convey the content of a music resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/TactileNotation">
+    <rdfs:label>Tactile notation used</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Notation"/>
+    <skos:definition>Information on the symbol system used to convey the content of a tactile resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MovementNotation">
+    <rdfs:label>Movement notation used</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Notation"/>
+    <skos:definition>Information on the symbol system used to convey the content of a movement resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Illustration">
+    <rdfs:label>Illustrative content</rdfs:label>
+    <skos:definition>Information about content intended to illustrate a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/SupplementaryContent">
+    <rdfs:label>Supplementary material</rdfs:label>
+    <skos:definition>Index, bibliography, appendix, etc. intended to supplement the primary content of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ColorContent">
+    <rdfs:label>Color content</rdfs:label>
+    <skos:definition>Color characteristics of a resource, e.g., black and white, multicolored, etc.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/SoundContent">
+    <rdfs:label>Sound content</rdfs:label>
+    <skos:definition>Indication of whether the production of sound is an integral part of the resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AspectRatio">
+    <rdfs:label>Aspect ratio</rdfs:label>
+    <skos:definition>Proportional relationship between an image's width and its height.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicFormat">
+    <rdfs:label>Notated music format</rdfs:label>
+    <skos:definition>Layout for content of a resource that is presented in the form of musical notation.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Scale">
+    <rdfs:label>Scale</rdfs:label>
+    <skos:definition>Ratio of the dimensions of a form contained or embodied in a resource to the dimensions of the entity it represents, e.g., for images or cartographic resources.</skos:definition>
+    <dcterms:modified>2017-02-03 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Cartographic">
+    <rdfs:label>Cartographic information</rdfs:label>
+    <skos:definition>Content that represents the whole or part of the earth, any celestial body, or imaginary place at any scale.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Projection">
+    <rdfs:label>Projection</rdfs:label>
+    <skos:definition>Method or system used to represent the surface of the earth or of a celestial sphere on a plane.</skos:definition>
+    <dcterms:modified>2017-02-03 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Classification">
+    <rdfs:label>Classification entity</rdfs:label>
+    <skos:definition>System of coding and organizing materials according to their subject.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ClassificationDdc">
+    <rdfs:label>DDC Classification</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <skos:definition>Dewey Decimal Classification number used for subject access.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ClassificationLcc">
+    <rdfs:label>LCC Classification</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <skos:definition>Library of Congress Classification number used for subject access.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ClassificationUdc">
+    <rdfs:label>UDC Classification</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <skos:definition>Universal Decimal Classification number used for subject access.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ClassificationNlm">
+    <rdfs:label>NLM classification</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <skos:definition>National Library of Medicine Classification number used for subject access</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Frequency">
+    <rdfs:label>Frequency</rdfs:label>
+    <skos:definition>Information about intervals at which the parts of a serially produced resource or the updates to an integrating resource are issued.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Issuance">
+    <rdfs:label>Mode of issuance</rdfs:label>
+    <skos:definition>Information about whether a resource is issued in one or more parts, the way it is updated, and its intended termination.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ProvisionActivity">
+    <rdfs:label>Provider entity</rdfs:label>
+    <skos:definition>Information about the agent or place relating to the publication, printing, distribution, issue, release, or production of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Distribution">
+    <rdfs:label>Distributor</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ProvisionActivity"/>
+    <skos:definition>Information relating to distribution of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Manufacture">
+    <rdfs:label>Manufacturer</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ProvisionActivity"/>
+    <skos:definition>Information relating to manufacture of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Publication">
+    <rdfs:label>Publisher</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ProvisionActivity"/>
+    <skos:definition>Information relating to publication of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Production">
+    <rdfs:label>Producer</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ProvisionActivity"/>
+    <skos:definition>Information relating to production of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AcquisitionSource">
+    <rdfs:label>Acquisition source</rdfs:label>
+    <skos:definition>Information about an organization, person, etc., from which a resource may be obtained.</skos:definition>
+    <dcterms:modified>2017-02-06 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/CopyrightRegistration">
+    <rdfs:label>Copyright registration</rdfs:label>
+    <skos:definition>Copyright or Legal Deposit registration information</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-05-04 (Class name corrected)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/CoverArt">
+    <rdfs:label>Cover art</rdfs:label>
+    <skos:definition>Cover illustration of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Review">
+    <rdfs:label>Review</rdfs:label>
+    <skos:definition>Review of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/TableOfContents">
+    <rdfs:label>Table of contents</rdfs:label>
+    <skos:definition>Table of contents of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Extent">
+    <rdfs:label>Extent</rdfs:label>
+    <skos:definition>Number and type of units and/or subunits making up a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/BaseMaterial">
+    <rdfs:label>Base material</rdfs:label>
+    <skos:definition>Underlying physical material of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AppliedMaterial">
+    <rdfs:label>Applied material</rdfs:label>
+    <skos:definition>Physical or chemical substance applied to a base material of a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Emulsion">
+    <rdfs:label>Emulsion</rdfs:label>
+    <skos:definition>Suspension of light-sensitive chemicals used as a coating on a microfilm or microfiche, e.g., silver halide.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Mount">
+    <rdfs:label>Mount</rdfs:label>
+    <skos:definition>Physical material used for the support or backing to which the base material of a resource has been attached.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ProductionMethod">
+    <rdfs:label>Production method</rdfs:label>
+    <skos:definition>Process used to produce a resource</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Generation">
+    <rdfs:label>Generation</rdfs:label>
+    <skos:definition>Relationship between an original carrier and the carrier of a reproduction made from the original.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Layout">
+    <rdfs:label>Layout</rdfs:label>
+    <skos:definition>Arrangement of text, images, tactile notation, etc., in a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/BookFormat">
+    <rdfs:label>Book format</rdfs:label>
+    <skos:definition>Result of folding a printed sheet to form a gathering of leaves.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/FontSize">
+    <rdfs:label>Font size</rdfs:label>
+    <skos:definition>Size of the type used to represent the characters and symbols in a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Polarity">
+    <rdfs:label>Polarity</rdfs:label>
+    <skos:definition>Relationship of the colors and tones in an image to the colors and tones of the object reproduced.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ReductionRatio">
+    <rdfs:label>Reduction ratio</rdfs:label>
+    <skos:definition>Size of a micro-image in relation to the original from which it was produced.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic">
+    <rdfs:label>Sound characteristic</rdfs:label>
+    <skos:definition>Technical specification relating to the encoding of sound in a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/RecordingMethod">
+    <rdfs:label>Type of recording</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Method used to encode audio content for playback, e.g., analog, digital.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/RecordingMedium">
+    <rdfs:label>Recording medium</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Type of medium used to record sound on an audio carrier, e.g., magnetic, optical.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/PlayingSpeed">
+    <rdfs:label>Playing speed</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Speed at which an audio carrier must be operated to produce the sound intended, e.g., 78 rpm, 19 cm/s.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/GrooveCharacteristic">
+    <rdfs:label>Groove characteristic</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Groove width of an analog disc or the groove pitch of an analog cylinder, e.g., coarse groove, microgroove</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-26 (fixed typo in definition)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Fixed name of property)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/TrackConfig">
+    <rdfs:label>Track configuration</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Configuration of the audio track on a sound-track film, e.g., center track, edge track.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/TapeConfig">
+    <rdfs:label>Tape configuration</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Number of tracks on an audiotape, e.g., 12 track.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/PlaybackChannels">
+    <rdfs:label>Configuration of playback channels</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Configuration/number of sound channels used to make a recording, such as one channel for a monophonic recording, e.g., mono, stereo, quadraphonic, surround.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic">
+    <rdfs:label>Special playback characteristics</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Equalization system, noise reduction system, etc., used in making an audio recording, e.g., CCIR standard, CX encoded, Dolby.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic">
+    <rdfs:label>Projection characteristic</rdfs:label>
+    <skos:definition>Technical specification relating to the projection of a motion picture film.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/PresentationFormat">
+    <rdfs:label>Presentation format</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"/>
+    <skos:definition>Format used in the production of a projected image, e.g., Cinerama, IMAX.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ProjectionSpeed">
+    <rdfs:label>Projection speed</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"/>
+    <skos:definition>Speed at which a projected carrier must be operated to produce the moving image intended, e.g., 20 fps.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/VideoCharacteristic">
+    <rdfs:label>Video characteristic</rdfs:label>
+    <skos:definition>Technical specification relating to the encoding of video images in a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/VideoFormat">
+    <rdfs:label>Video format</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/VideoCharacteristic"/>
+    <skos:definition>Standard, etc., used to encode the analog video content of a resource, e.g., Beta, 8mm.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/BroadcastStandard">
+    <rdfs:label>Broadcast standard</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/VideoCharacteristic"/>
+    <skos:definition>System used to format a video resource for television broadcast, e.g., HDTV, PAL.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic">
+    <rdfs:label>Digital characteristic</rdfs:label>
+    <skos:definition>Technical specification relating to the digital encoding of text, image, audio, video, and other types of data in a resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/FileType">
+    <rdfs:label>File type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>General type of data content encoded in a computer file, e.g., text file, audio file.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/EncodingFormat">
+    <rdfs:label>Encoding format</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Schema, standard, etc., used to encode the digital content of a resource, e.g., MP3, XML, JPEG.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/FileSize">
+    <rdfs:label>File size</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Number of bytes in a digital file, e.g., 162 KB.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Resolution">
+    <rdfs:label>Resolution</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Clarity or fineness of detail in a digital image, expressed by the measurement of the image in pixels, etc., e.g., 3.1 megapixels.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/RegionalEncoding">
+    <rdfs:label>Regional encoding</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Identification of the region of the world for which a videodisc has been encoded, e.g., region 4.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/EncodedBitrate">
+    <rdfs:label>Encoded bitrate</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Speed at which streaming audio, video, etc., is designed to play, e.g., 32 kbps.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/CartographicDataType">
+    <rdfs:label>Digital cartographic data type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Data type for encoding of geospatial information in a cartographic resource, e.g., raster, vector, point.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/CartographicObjectType">
+    <rdfs:label>Digital cartographic object type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Object type for encoding of geospatial information in a cartographic resource, e.g., point, line, polygon.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ObjectCount">
+    <rdfs:label>Digital cartographic object count</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Number of objects in encoded geospatial information in a cartographic resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/SystemRequirement">
+    <rdfs:label>System Requirement</rdfs:label>
+    <skos:definition>Equipment or system requirements beyond what is normal and obvious for the type of carrier or type of file, such as make and model of equipment or hardware, operating system, amount of memory, programming language, other necessary software, any plug-ins or peripherals required to play, view, or run the resource, etc.</skos:definition>
+    <dcterms:modified>2017-02-06 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/EnumerationAndChronology">
+    <rdfs:label>Enumeration and chronology</rdfs:label>
+    <skos:definition>Numbering or other enumeration and dates associated with issues or items held.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Enumeration">
+    <rdfs:label>Enumeration</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/EnumerationAndChronology"/>
+    <skos:definition>Numbering or other enumeration associated with issues or items held.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Chronology">
+    <rdfs:label>Chronology</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/EnumerationAndChronology"/>
+    <skos:definition>Dates associated with issues or items held.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Sublocation">
+    <rdfs:label>Sublocation</rdfs:label>
+    <skos:definition>Specific place within the holding entity where the item is located or made available.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ShelfMark">
+    <rdfs:label>Shelf location</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Piece/item identifier, such as a call or other type of number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ShelfMarkDdc">
+    <rdfs:label>DDC call number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ShelfMark"/>
+    <skos:definition>Shelf mark based on Dewey Decimal Classification.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ShelfMarkLcc">
+    <rdfs:label>LCC call number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ShelfMark"/>
+    <skos:definition>Shelf mark based on Library of Congress Classification.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ShelfMarkUdc">
+    <rdfs:label>UDC call number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ShelfMark"/>
+    <skos:definition>Shelf mark based on Universal Decimal Classification.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ShelfMarkNlm">
+    <rdfs:label>NLM call number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ShelfMark"/>
+    <skos:definition>Shelf mark based on National Library of Medicine Classification.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/UsageAndAccessPolicy">
+    <rdfs:label>Use and access conditions</rdfs:label>
+    <skos:definition>General statement of allowances and restrictions on access to a resource, including retention, reproduction, access, and lending.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AccessPolicy">
+    <rdfs:label>Access policy</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/UsageAndAccessPolicy"/>
+    <skos:definition>Access restrictions and allowances regarding access to a resource, e.g., lending policy, access restrictions, embargos.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/UsePolicy">
+    <rdfs:label>Use policy</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/UsageAndAccessPolicy"/>
+    <skos:definition>Usage limitations placed on a resource with respect to reproduction, publication, exhibition, etc..</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/RetentionPolicy">
+    <rdfs:label>Retention policy</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/UsageAndAccessPolicy"/>
+    <skos:definition>Policy of holding institution for retaining resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ImmediateAcquisition">
+    <rdfs:label>Immediate acquisition</rdfs:label>
+    <skos:definition>Information about the circumstances, e.g., source, date, method, under which the resource was directly acquired.</skos:definition>
+    <dcterms:modified>2017-02-06 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Ansi">
+    <rdfs:label>ANSI number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>American National Standards Institute identifier.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AudioIssueNumber">
+    <rdfs:label>Audio issue number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Number assigned by publishers of sound recordings to identify the issue designation, or serial identification, of the resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Revised property name and definition)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AudioTake">
+    <rdfs:label>Audio recording take</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier assigned to the smallest identifiable unit of a recording session, e.g., a specific recording of an individual song.</skos:definition>
+    <dcterms:modified>2017-02-03 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Barcode">
+    <rdfs:label>Barcode</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Optical machine-readable representation of data relating to the item to which it is attached.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Moved to Identifier class group from Item group)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Coden">
+    <rdfs:label>CODEN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier for scientific and technical periodical titles assigned by the International CODEN Section of Chemical Abstracts Service.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/CopyrightNumber">
+    <rdfs:label>Copyright-legal deposit number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier assigned to a copyright registration or legal deposit.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/DissertationIdentifier">
+    <rdfs:label>Dissertation Identifier</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier assigned to a thesis or dissertation for identification purposes .</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Doi">
+    <rdfs:label>DOI</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Digital Object Identifier.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Ean">
+    <rdfs:label>EAN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Article Identifier.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Fingerprint">
+    <rdfs:label>Fingerprint identifier</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier that is used to assist in the identification of antiquarian books by recording information comprising groups of characters taken from specified positions on specified pages of the book.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Gtin14Number">
+    <rdfs:label>Global Trade Item Number 14</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>14 digit number assigned to identify trade items as various packaging levels. GTIN-14 encompasses EAN/UCC-128 and ITF-14.</skos:definition>
+    <dcterms:modified>2017-02-03 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Hdl">
+    <rdfs:label>Handle</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Unique and persistent identifier for digital objects developed by the Corporation for National Research Initiatives.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Isan">
+    <rdfs:label>ISAN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Audiovisual Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Isbn">
+    <rdfs:label>ISBN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Book Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Ismn">
+    <rdfs:label>ISMN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Music Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Isni">
+    <rdfs:label>ISNI</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Name Identifier, a unique, persistent reference number for the identities of contributors to creative works.</skos:definition>
+    <dcterms:modified>2017-02-03 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Iso">
+    <rdfs:label>ISO number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Organization for Standardization standard number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Isrc">
+    <rdfs:label>ISRC</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Recording Code.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Issn">
+    <rdfs:label>ISSN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Serial Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/IssnL">
+    <rdfs:label>ISSN-L</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Serial Number that links together various media versions of a continuing resource.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Istc">
+    <rdfs:label>ISTC</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Text Code, a numbering system developed to enable the unique identification of textual works.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Iswc">
+    <rdfs:label>ISWC</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>International Standard Musical Work Code, a unique, persistent reference number for the identification of musical works.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/LcOverseasAcq">
+    <rdfs:label>LC acquisition program</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identification number assigned by the Library of Congress to works acquired through one of its collaborative overseas acquisition programs.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Lccn">
+    <rdfs:label>LCCN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Library of Congress Control Number that identifies a resource description.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Local">
+    <rdfs:label>Local identifier</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier established locally and not a standard number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MatrixNumber">
+    <rdfs:label>Audio matrix number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Matrix identifier assigned to the master from which a specific sound recording was pressed.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Revised definition)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicDistributorNumber">
+    <rdfs:label>Music distributor number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier appearing on a resource assigned by a distributor to a specific audio recording, notated music publication, music-related publication, or videorecording.</skos:definition>
+    <dcterms:modified>2017-02-07 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicPlate">
+    <rdfs:label>Music plate number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifiers assigned by a music publisher or printer to the printing plates for the notated portion of a notated music publication, or an identifier that emulates the printing plate tradition in contemporary publications.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Revised definition)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/MusicPublisherNumber">
+    <rdfs:label>Music publisher number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identifier assigned to a notated music publication other than an issue, matrix, or plate number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Revised definition)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Nbn">
+    <rdfs:label>NBN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>National Bibliography Number that identifies a resource description.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/PostalRegistration">
+    <rdfs:label>Postal registration number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Number assigned to a publication for which the specified postal service permits the use of a special mailing class privilege.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/PublisherNumber">
+    <rdfs:label>Other publisher number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Number assigned by a publisher that is not one of the specific defined types.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/ReportNumber">
+    <rdfs:label>Technical report number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identification number of a technical report that is not a Standard Technical Report Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Sici">
+    <rdfs:label>SICI</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Serial Item and Contribution Identifier.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/StockNumber">
+    <rdfs:label>Stock number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identification number used for stock purposes and assigned by agencies such as distributors, publishers, or vendors.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Strn">
+    <rdfs:label>STRN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Standard Technical Report Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/StudyNumber">
+    <rdfs:label>Study number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Identification number for a computer data file.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Upc">
+    <rdfs:label>UPC</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Universal Product Code.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/Urn">
+    <rdfs:label>URN</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Uniform Resource Number.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/VideoRecordingNumber">
+    <rdfs:label>Video recording number</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Number assigned by a publisher to a video recording.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Corrected case in class name)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/AdminMetadata">
+    <rdfs:label>Administrative metadata</rdfs:label>
+    <skos:definition>Metadata about the metadata, especially provenance information.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/DescriptionConventions">
+    <rdfs:label>Description conventions</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <skos:definition>Rules used for the descriptive content of the resource description.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-24 (fixed class name)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/GenerationProcess">
+    <rdfs:label>Generation process</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <skos:definition>Indication of the program or process used to generate the description by application of a particular transformation.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-24 (fixed class name)</dcterms:modified>
+  </owl:Class>
+  <owl:Class rdf:about="http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication">
+    <rdfs:label>Metadata authentication</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <skos:definition>Indication of specific types of reviews that have been carried out on the description information.</skos:definition>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (fixed class name)</dcterms:modified>
+  </owl:Class>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/identifiedBy">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Character string associated with a resource that serves to differentiate that resource from other resources, i.e., that uniquely identifies an entity.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Identifier</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/identifies"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-05-04 (New inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/identifies">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
+    <skos:definition>Resource that is associated with a character string that serves to differentiate one resource from another.</skos:definition>
+    <rdfs:label>Resouce identified</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/identifiedBy"/>
+    <dcterms:modified>2017-02-03 (New inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/qualifier">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Qualifier of information, such as an addition to a title to make it unique or qualifying information associated with an identifier.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Qualifier</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/adminMetadata">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <skos:definition>Metadata about the metadata, especially provenance information.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Administrative metadata</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/date">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date designation associated with a resource or element of description, such as date of title variation; year a degree was awarded; date associated with the publication, printing, distribution, issue, release or production of a resource. May be date typed.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Date</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/place">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Place"/>
+    <skos:definition>Geographic location or place entity associated with a resource or element of description, such as the place associated with the publication, printing, distribution, issue, release or production of a resource, place of an event.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Place</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/agent">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Entity associated with a resource or element of description, such as the name of the entity responsible for the content or of the publication, printing, distribution, issue, release or production of a resource.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Associated agent</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/count">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Number associated with a measure of units, such as the number of units and/or subunits making up a resource.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Number of units</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/unit">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Unit"/>
+    <skos:definition>Units in which a value is expressed, such as the physical or logical constituent of a resource (e.g., a volume, audiocassette, film reel, a map, a digital file).</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Type of unit</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/code">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>String of characters that serves as a code representing information.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Code</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/source">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Source"/>
+    <skos:definition>Resource from which value or label came or was derived, such as the formal source/scheme from which a classification number is taken or derived, list from which an agent name is taken or derived, source within which an identifier is unique.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Source</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/note">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Note"/>
+    <skos:definition>General textual information relating to a resource, such as Information about a specific copy of a resource or information about a particular attribute of a resource.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Note</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/status">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Status"/>
+    <skos:definition>Designation of the validity or position of something, such as indication that the classification number is canceled or invalid, circulation availability of an item, indication of whether the identifier is canceled or invalid.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Status</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/part">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Part of a resource to which information applies.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Part</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/language">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Language"/>
+    <skos:definition>Language associated with a resource or its parts.</skos:definition>
+    <rdfs:comment>Used with Unspecified</rdfs:comment>
+    <rdfs:label>Language information</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/content">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Content"/>
+    <skos:definition>Categorization reflecting the fundamental form of communication in which the content is expressed and the human sense through which it is intended to be perceived.</skos:definition>
+    <rdfs:label>Content type</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/media">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Media"/>
+    <skos:definition>Categorization reflecting the general type of intermediation device required to view, play, run, etc., the content of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Media type</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/carrier">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Carrier"/>
+    <skos:definition>Categorization reflecting the format of the storage medium and housing of a carrier.</skos:definition>
+    <rdfs:label>Carrier type</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/genreForm">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/GenreForm"/>
+    <skos:definition>Form category or genre to which a resource belongs</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Genre/form</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/title">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
+    <skos:definition>Name given to a resource.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Title resource</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/mainTitle">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Title being addressed. Possible title component.</skos:definition>
+    <rdfs:label>Main title</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/subtitle">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Word, character, or group of words and/or characters that contains the remainder of the title after the main title. Possible title component.</skos:definition>
+    <rdfs:label>Subtitle</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/partNumber">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Part or section enumeration of a title. Possible title component.</skos:definition>
+    <rdfs:label>Part number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/partName">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Part or section name of a title. Possible title component.</skos:definition>
+    <rdfs:label>Part title</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/variantType">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/VariantTitle"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Type of title variation, e.g., acronym, cover, spine, earlier, later, series version.</skos:definition>
+    <rdfs:label>Variant title type</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/originDate">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date or date range associated with the creation of a Work.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/date"/>
+    <rdfs:label>Associated title date</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/originPlace">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Place"/>
+    <skos:definition>Place from which the creation of the Work originated.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/place"/>
+    <rdfs:label>Associated title place</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/historyOfWork">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Information about the history of a Work.</skos:definition>
+    <rdfs:label>History of the work</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/musicMedium">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicMedium"/>
+    <skos:definition>Instrumental, vocal, and/or other medium of performance for which a musical resource was originally conceived, written or performed.</skos:definition>
+    <rdfs:label>Music medium of performance</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/instrument">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicInstrument"/>
+    <skos:definition>Instrument for which a musical Work is appropriate.</skos:definition>
+    <rdfs:label>Instrument</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/instrumentalType">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicInstrument"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Specific role of instrument, such as alternate, doubling, solo, ensemble.</skos:definition>
+    <rdfs:label>Instrument role</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/ensemble">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicEnsemble"/>
+    <skos:definition>Ensemble for which a musical work is appropriate.</skos:definition>
+    <rdfs:label>Ensemble</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/ensembleType">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicEnsemble"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Specific type of ensemble, such as orchestra, band, guitar ensemble.</skos:definition>
+    <rdfs:label>Ensemble type</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/voice">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicVoice"/>
+    <skos:definition>Voice for which a musical work is appropriate, such as soprano, tenor, mixed.</skos:definition>
+    <rdfs:label>Voice</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/voiceType">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicVoice"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Specific type of voice group, such as chorus, solo.</skos:definition>
+    <rdfs:label>Type of voice</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/musicSerialNumber">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Numeric designation for musical works consecutively numbered in music reference sources.</skos:definition>
+    <rdfs:label>Music serial number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/musicOpusNumber">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Numeric designation of a musical work assigned by a composer, publisher, or a musicologist.</skos:definition>
+    <rdfs:label>Music opus number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/musicThematicNumber">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Numeric designation for a musical work as found in a thematic index for the composer.</skos:definition>
+    <rdfs:label>Music thematic number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/musicKey">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Pitch and mode for music.</skos:definition>
+    <rdfs:label>Music key</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/legalDate">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date of legal work, or promulgation of a law, or signing of a treaty.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/date"/>
+    <rdfs:label>Date of legal work</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/version">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Term or terms that identify works such as arranged for music, vulgate for religious work, etc.</skos:definition>
+    <rdfs:label>Version</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/natureOfContent">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Characterization that epitomizes the primary content of a resource, e.g., field recording of birdsong; combined time series analysis and graph plotting system.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Content nature</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/geographicCoverage">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/GeographicCoverage"/>
+    <skos:definition>Geographic coverage of the content of the resource.</skos:definition>
+    <rdfs:label>Geographic coverage</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-06 (Changed from data to object property)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/temporalCoverage">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Time period coverage of the content of the resource.</skos:definition>
+    <rdfs:label>Temporal coverage</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/intendedAudience">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/IntendedAudience"/>
+    <skos:definition>Information that identifies the specific audience or intellectual level for which the content of the resource is considered appropriate.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Intended audience</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/arrangement">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Arrangement"/>
+    <skos:definition>Information about the organization and arrangement of a collection of resources.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Organization and arrangement</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/pattern">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Arrangement"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Pattern of arrangement of materials within a unit.</skos:definition>
+    <rdfs:label>Arrangement of material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hierarchicalLevel">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Arrangement"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Hierarchical position of the described materials relative to other material from the same source.</skos:definition>
+    <rdfs:label>Hierarchical level of material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/organization">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Arrangement"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Manner in which the resource is divided into smaller units.</skos:definition>
+    <rdfs:label>Organization of material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/dissertation">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Dissertation"/>
+    <skos:definition>Work presented as part of the formal requirements for an academic degree.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Dissertation Information</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/degree">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Dissertation"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Degree for which author was a candidate.</skos:definition>
+    <rdfs:label>Degree</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/grantingInstitution">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Dissertation"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Name of degree granting institution.</skos:definition>
+    <rdfs:label>Degree issuing institution</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/summary">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Summary"/>
+    <skos:definition>Summary or abstract of the resource described.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Summary content</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/capture">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Capture"/>
+    <skos:definition>Information about place and date associated with the capture (e.g., recording, filming) of the content of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Capture of content</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/notation">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Notation"/>
+    <skos:definition>Alphabet, script, or symbol system used to convey the content of the resource, including specialized scripts, typefaces, tactile notation, movement notation, and musical notation.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Notation system</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/contentAccessibility">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ContentAccessibility"/>
+    <skos:definition>Information that assists those with a sensory impairment for greater understanding of content, e.g., captions.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Content accessibility information</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (changed from data to object property)</dcterms:modified>
+    <dcterms:modified>2017-03-15 fixed typo in range</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/illustrativeContent">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Illustration"/>
+    <skos:definition>Information about content intended to illustrate a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Illustrative content information</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/supplementaryContent">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/SupplementaryContent"/>
+    <skos:definition>Material such as an index, bibliography, appendix intended to supplement the primary content of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Supplementary material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/colorContent">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ColorContent"/>
+    <skos:definition>Color characteristics, e.g., black and white, multicolored.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Color content</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/soundContent">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundContent"/>
+    <skos:definition>Indication of whether the production of sound is an integral part of the resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Sound content</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/aspectRatio">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/AspectRatio"/>
+    <skos:definition>Proportional relationship between an image's width and its height.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Aspect ratio</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/musicFormat">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/MusicFormat"/>
+    <skos:definition>Layout for content of a resource that is presented in the form of musical notation, such as full score, condensed score, vocal score, etc.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Format of notated music</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/duration">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Information about the playing time, running time, etc. of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Duration</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/scale">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Scale"/>
+    <skos:definition>Ratio of the dimensions of a form contained or embodied in a resource to the dimensions of the entity it represents, e.g., for images or cartographic resources.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Scale</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (changed from data to object property)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/cartographicAttributes">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <skos:definition>Cartographic data that identifies characteristics of the resource, such as coordinates, projection, etc.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Cartographic data</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/ascensionAndDeclination">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>System for identifying the location of a celestial object in the sky covered by the cartographic content of a resource using the angles of right ascension and declination.</skos:definition>
+    <rdfs:label>Cartographic ascension and declination</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/coordinates">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Mathematical system for identifying the area covered by the cartographic content of a resource, expressed either by means of longitude and latitude on the surface of planets or by the angles of right ascension and declination for celestial cartographic content.</skos:definition>
+    <rdfs:label>Cartographic coordinates</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/equinox">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>One of two points of intersection of the ecliptic and the celestial equator, occupied by the sun when its declination is 0 degrees.</skos:definition>
+    <rdfs:label>Cartographic equinox</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/exclusionGRing">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Coordinate pairs that identify the closed non-intersecting boundary of the area contained within the G-polygon outer ring that is excluded.</skos:definition>
+    <rdfs:label>Cartographic G ring area excluded</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/outerGRing">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Coordinate pairs that identify the closed non-intersecting boundary of the area covered.</skos:definition>
+    <rdfs:label>Cartographic outer G ring area covered</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/projection">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Cartographic"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Projection"/>
+    <skos:definition>Method or system used to represent the surface of the earth or of a celestial sphere on a plane.</skos:definition>
+    <rdfs:label>Cartographic projection</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (changed from data to object property)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/awards">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Information on awards associated with the described resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Award note</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/credits">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Information in note form of credits for persons or organizations who have participated in the creation and/or production of the resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Credits note</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/subject">
+    <skos:definition>Subject term(s) describing a resource.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Subject</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/classification">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <skos:definition>Classification number in any scheme.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Classification</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/schedulePart">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Designates whether the classification number is from the standard or optional part of a schedule or table.</skos:definition>
+    <rdfs:label>Classification designation</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/edition">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Edition of the classification scheme, such as full, abridged or a number, when a classification scheme designates editions.</skos:definition>
+    <rdfs:label>Classification scheme edition</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/itemPortion">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Number attached to a classification string that indicates a particular item.</skos:definition>
+    <rdfs:label>Classification item number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/classificationPortion">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Classification number (single class number or beginning number of a span) that indicates the subject by applying a formal system of coding and organizing resources.</skos:definition>
+    <rdfs:label>Classification number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/spanEnd">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Ending number of classification number span.</skos:definition>
+    <rdfs:label>Classification number span end</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/table">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Number of the table from which the classification number in a subdivision entry is taken, e.g., a DDC table.</skos:definition>
+    <rdfs:label>Classification table identification</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/tableSeq">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Classification"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Sequence number or other identifier for an internal classification sub arrangement or add in a classification scheme.</skos:definition>
+    <rdfs:label>Classification table sequence number</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/responsibilityStatement">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Statement relating to any persons, families, or corporate bodies responsible for the creation of, or contributing to the content of a resource; usually transcribed.</skos:definition>
+    <rdfs:label>Creative responsibility statement</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/editionStatement">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Information identifying the edition or version of the resource and associated statements of responsibility for the edition; usually transcribed.</skos:definition>
+    <rdfs:label>Edition statement</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/editionEnumeration">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Enumeration of the edition; usually transcribed.</skos:definition>
+    <rdfs:label>Edition enumeration</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/provisionActivityStatement">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Statement relating to providers of a resource; usually transcribed.</skos:definition>
+    <rdfs:label>Provider statement</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/seriesStatement">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Statement of the series the resource is in; usually transcribed; includes the ISSN if applicable.</skos:definition>
+    <rdfs:label>Series statement</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/seriesEnumeration">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Series enumeration of the resource; usually transcribed.</skos:definition>
+    <rdfs:label>Series enumeration</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/subseriesStatement">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Statement of the subseries the resource is in; usually transcribed; includes the ISSN if applicable.</skos:definition>
+    <rdfs:label>Subseries statement</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/subseriesEnumeration">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Subseries enumeration of the resource; usually transcribed.</skos:definition>
+    <rdfs:label>Subseries enumeration</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/frequency">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Frequency"/>
+    <skos:definition>Intervals at which the parts of a serially produced resource or the updates to an integrating resource are issued.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Frequency</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/preferredCitation">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Citation to the resource preferred by its custodian of the resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Preferred citation</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/issuance">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Issuance"/>
+    <skos:definition>Categorization reflecting whether a resource is issued in one or more parts, the way it is updated, and its intended termination.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Mode of issuance</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/firstIssue">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Beginning date of a resource and/or the sequential designations.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Multipart first issue</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/lastIssue">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Ending date of a resource and/or the sequential designations.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Multipart last issue</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/provisionActivity">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ProvisionActivity"/>
+    <skos:definition>Place, name, and/or date information relating to the publication, printing, distribution, issue, release, production, etc. of a resource.</skos:definition>
+    <rdfs:label>Provision activity</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (revised label and slightly revised definition)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/copyrightDate">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date associated with a claim of protection under copyright or a similar regime.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/date"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Copyright date</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/custodialHistory">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Information about the provenance, such as origin, ownership and custodial history (chain of custody), of a resource.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Custodial history</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/acquisitionTerms">
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Conditions under which the publisher, distributor, etc., will normally supply a resource, e.g., price of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Terms of acquisition</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/acquisitionSource">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/AcquisitionSource"/>
+    <skos:definition>Information about an organization, person, etc., from which a resource may be obtained.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Source of acquisition</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-06 (Changed from data to object property</dcterms:modified>
+    <dcterms:modified>slight change to definition)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/copyrightRegistration">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/CopyrightRegistration"/>
+    <skos:definition>Copyright and Legal Deposit registration information</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Copyright registration information</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-05-04 (Corrected expected value)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/coverArt">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/CoverArt"/>
+    <skos:definition>Cover art image of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Cover art</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/review">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Review"/>
+    <skos:definition>Review of a resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Review content</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/tableOfContents">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/TableOfContents"/>
+    <skos:definition>Table of contents of the described resource.</skos:definition>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Table of contents content</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/extent">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Extent"/>
+    <skos:definition>Number and type of units and/or subunits making up a resource.</skos:definition>
+    <rdfs:label>Extent</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/dimensions">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Measurements of the carrier or carriers and/or the container of a resource.</skos:definition>
+    <rdfs:label>Dimensions</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/baseMaterial">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/BaseMaterial"/>
+    <skos:definition>Underlying physical material of a resource.</skos:definition>
+    <rdfs:label>Base material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/appliedMaterial">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/AppliedMaterial"/>
+    <skos:definition>Physical or chemical substance applied to a base material of a resource.</skos:definition>
+    <rdfs:label>Applied material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/emulsion">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Emulsion"/>
+    <skos:definition>Suspension of light-sensitive chemicals used as a coating on a microfilm or microfiche, e.g., silver halide.</skos:definition>
+    <rdfs:label>Emulsion</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/mount">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Mount"/>
+    <skos:definition>Physical material used for the support or backing to which the base material of a resource has been attached.</skos:definition>
+    <rdfs:label>Mount material</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/productionMethod">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ProductionMethod"/>
+    <skos:definition>Process used to produce a resource.</skos:definition>
+    <rdfs:label>Production method</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/generation">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Generation"/>
+    <skos:definition>Relationship between an original carrier and the carrier of a reproduction made from the original.</skos:definition>
+    <rdfs:label>Generation</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/layout">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Layout"/>
+    <skos:definition>Arrangement of text, images, tactile notation, etc., in a resource.</skos:definition>
+    <rdfs:label>Layout</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/bookFormat">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/BookFormat"/>
+    <skos:definition>Result of folding a printed sheet to form a gathering of leaves.</skos:definition>
+    <rdfs:label>Book format</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/fontSize">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/FontSize"/>
+    <skos:definition>Size of the type used to represent the characters and symbols in a resource.</skos:definition>
+    <rdfs:label>Font size</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/polarity">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Polarity"/>
+    <skos:definition>Relationship of the colors and tones in an image to the colors and tones of the object reproduced.</skos:definition>
+    <rdfs:label>Polarity</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/reductionRatio">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ReductionRatio"/>
+    <skos:definition>Size of a micro-image in relation to the original from which it was produced.</skos:definition>
+    <rdfs:label>Reduction ratio</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/soundCharacteristic">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"/>
+    <skos:definition>Technical specification relating to the encoding of sound in a resource.</skos:definition>
+    <rdfs:label>Sound characteristic</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-21 (fixed name and range typos)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/projectionCharacteristic">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"/>
+    <skos:definition>Technical specification relating to the projection of a motion picture film.</skos:definition>
+    <rdfs:label>Projection characteristic</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (fixed typo in property name)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/videoCharacteristic">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/VideoCharacteristic"/>
+    <skos:definition>Technical specification relating to the encoding of video images in a resource</skos:definition>
+    <rdfs:label>Video characteristic</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/digitalCharacteristic">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"/>
+    <skos:definition>Technical specification relating to the digital encoding of text, image, audio, video, and other types of data in a resource.</skos:definition>
+    <rdfs:label>Digital characteristic</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/systemRequirement">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/SystemRequirement"/>
+    <skos:definition>Equipment or system requirement beyond what is normal and obvious for the type of carrier or type of file, such as make and model of equipment or hardware, operating system, amount of memory, programming language, other necessary software, any plug-ins or peripherals required to play, view, or run the resource, etc.</skos:definition>
+    <rdfs:label>Equipment or system requirements</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-06 (Changed from data to object property, changed property name from plural to singular)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/enumerationAndChronology">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/EnumerationAndChronology"/>
+    <skos:definition>Numbering and dates of issues or items held.</skos:definition>
+    <rdfs:label>Numbering or other enumeration and dates associated with issues or items held.</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/heldBy">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Entity holding the item or from which it is available.</skos:definition>
+    <rdfs:label>Held by</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/sublocation">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Sublocation"/>
+    <skos:definition>Specific place within the holding entity where the item is located or made available.</skos:definition>
+    <rdfs:label>Held in sublocation</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/physicalLocation">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Location in the holding agency where the item is shelved or stored.</skos:definition>
+    <rdfs:label>Storing or shelving location</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/shelfMark">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ShelfMark"/>
+    <skos:definition>Piece identifier, such as a call or other type of number.</skos:definition>
+    <rdfs:label>Shelf mark</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/electronicLocator">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <skos:definition>Electronic location from which the resource is available.</skos:definition>
+    <rdfs:label>Electronic location</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/UsageAndAccessPolicy"/>
+    <skos:definition>General statement of allowances and restrictions on access to a resource, including retention, reproduction, access, and lending.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Use and access condition</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/immediateAcquisition">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/ImmediateAcquisition"/>
+    <skos:definition>Information about the circumstances, e.g., source, date, method, under which the resource was directly acquired.</skos:definition>
+    <rdfs:label>Immediate acquisition</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-06 (Changed from data to object property)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/noteType">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Note"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Type of note.</skos:definition>
+    <rdfs:label>Note type</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:SymmetricProperty rdf:about="http://id.loc.gov/ontologies/bibframe/relatedTo">
+    <skos:definition>Any relationship between Work, Instance, and Item resources.</skos:definition>
+    <rdfs:label>Related resource</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:SymmetricProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasInstance">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Instance is related to described Work. For use to connect Works to Instances in the BIBFRAME structure.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Instance of Work</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/instanceOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/instanceOf">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Work the Instance described instantiates or manifests. For use to connect Instances to Works in the BIBFRAME structure.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Instance of</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasInstance"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasExpression">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Work that is an expression of a described Work. For use to relate Works under FRBR/RDA rules.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Expressed as</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/expressionOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/expressionOf">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Work that the described Work is an expression of. For use to connect Works under FRBR/RDA rules.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Expression of</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasExpression"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/itemOf">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Instance for which the described Item is an example.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Holding for</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasItem"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+    <dcterms:modified>2017-02-07 (slight revision of definition)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasItem">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
+    <skos:definition>Item which is an example of the described Instance.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Has holding</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/itemOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+    <dcterms:modified>2017-02-07 (slight revision of definition)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/eventContent">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Event"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <skos:definition>Work whose content is the described event.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Event content</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/eventContentOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/eventContentOf">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Event"/>
+    <skos:definition>Event that is the content of the described work.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:label>Has event content</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/eventContent"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:SymmetricProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasEquivalent">
+    <skos:definition>Resource embodies the same content as the described resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Equivalence</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:SymmetricProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasPart">
+    <skos:definition>Resource that is included either physically or logically in the described resource</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Has part</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/partOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/partOf">
+    <skos:definition>Resource in which the described resource is physically or logically contained.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Is part of</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasPart"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/accompaniedBy">
+    <skos:definition>Resource that accompanies the described resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Accompanied by</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompanies"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/accompanies">
+    <skos:definition>Resource that adds to or is issued with the described resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Accompanies</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompaniedBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasDerivative">
+    <skos:definition>Resource that is a modification of the described work.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Has derivative</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/derivativeOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/derivativeOf">
+    <skos:definition>Source work from which the described resource is derived.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Is derivative of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasDerivative"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/precededBy">
+    <skos:definition>Resource that precedes the resource being described, e.g., is earlier in time or before in narrative.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Preceded by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/succeededBy">
+    <skos:definition>Resource that succeeds the resource being described, e.g., later in time or after in a narrative.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Succeeded by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/references">
+    <skos:definition>Resource that is referenced by the described resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>References</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/referencedBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/referencedBy">
+    <skos:definition>Resource that references the described resource</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Referenced by</rdfs:label>
+    <rdfs:comment>Expected value Work, Instance or Item</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/references"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:SymmetricProperty rdf:about="http://id.loc.gov/ontologies/bibframe/issuedWith">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is issued on the same carrier as the resource being described.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompanies"/>
+    <rdfs:label>Issued with</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:SymmetricProperty>
+  <owl:SymmetricProperty rdf:about="http://id.loc.gov/ontologies/bibframe/otherPhysicalFormat">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is manifested in another physical carrier.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasEquivalent"/>
+    <rdfs:label>Has other physical format</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:SymmetricProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasReproduction">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that reproduces another Resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasEquivalent"/>
+    <rdfs:label>Reproduced as</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/reproductionOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/reproductionOf">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
+    <skos:definition>Resource that is a reproduction of another Resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasEquivalent"/>
+    <rdfs:label>Reproduction of</rdfs:label>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasReproduction"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/dataSource">
+    <skos:definition>Resource that is a data source to which the described resource is related. It may contain information about other files, printed sources, or collection procedures.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/relatedTo"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Data source</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasSeries">
+    <skos:definition>Resource in which the part has been issued; the title of the larger resource appears on the part.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/partOf"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>In series</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/seriesOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/seriesOf">
+    <skos:definition>Resource that is a part of a larger resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasPart"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Series container of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasSeries"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/hasSubseries">
+    <skos:definition>series resource that is part of another series.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/partOf"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Subseries</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/subseriesOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/subseriesOf">
+    <skos:definition>Series resource of which the described resource is a part.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasPart"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Subseries of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasSubseries"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/supplement">
+    <skos:definition>Resource that updates or otherwise complements the predominant resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompaniedBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Supplement</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/supplementTo"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/supplementTo">
+    <skos:definition>Resource that is updated or otherwise complemented by the augmenting resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompanies"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Supplement to</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/supplement"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/translation">
+    <skos:definition>Resource that translates the text of the source entity into a language different from that of the original.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasDerivative"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Translation as</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/translationOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (corrected subproperty)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/translationOf">
+    <skos:definition>Resource that has been translated, i.e., the text is expressed in a language different from that of the original resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/derivativeOf"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Translation of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/translation"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (corrected subproperty)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/originalVersion">
+    <skos:definition>Resource is the original version of which this resource is a reproduction.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/derivativeOf"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Original version</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/originalVersionOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/originalVersionOf">
+    <skos:definition>Original version of a resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/hasDerivative"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Original version of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/originalVersion"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/index">
+    <skos:definition>Resource has an accompanying index</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompaniedBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Has index</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/indexOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (corrected label)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/indexOf">
+    <skos:definition>Index that accompanies a resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompanies"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Index to</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/index"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:SymmetricProperty rdf:about="http://id.loc.gov/ontologies/bibframe/otherEdition">
+    <skos:definition>Resource has other available editions, for example simultaneously published language editions or reprints.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/derivativeOf"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Other edition</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-05-13 (symmetrical)</dcterms:modified>
+  </owl:SymmetricProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/findingAid">
+    <skos:definition>Relationship for archival, visual, and manuscript resources to a finding aid or similar control materials.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompaniedBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Finding aid</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/findingAidOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/findingAidOf">
+    <skos:definition>Finding aid or similar control materials for archival, visual, and manuscript resources.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/accompanies"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Finding aid for</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/findingAid"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/separatedFrom">
+    <skos:definition>Resource that spun off a part of its content to form a new resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Separated from</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/continuedInPartBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/splitInto">
+    <skos:definition>One of two or more resources resulting from the division of an earlier resource into separate resources.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Split into</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/continuesInPart"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/replacementOf">
+    <skos:definition>Earlier resource whose content has been replaced by a later resource, usually because the later resource contains updated or new information.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Preceded by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/replacedBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/replacedBy">
+    <skos:definition>Later resource used in place of an earlier resource, usually because the later resource contains updated or new information.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Succeeded by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/replacementOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/mergerOf">
+    <skos:definition>One of two or more resources which came together to form a new resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Merger of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/mergedToForm"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/mergedToForm">
+    <skos:definition>One of two or more resources that come together to form a new resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Merged to form</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/mergerOf"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/continues">
+    <skos:definition>Resource that is continued by the content of a later resource under a new title.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Continuation of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/continuedBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/continuesInPart">
+    <skos:definition>Resource that split into two or more separate resources with new titles.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Continuation in part of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/splitInto"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/absorbed">
+    <skos:definition>Resource that has been incorporated into another resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/precededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Absorption of</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/absorbedBy"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/absorbedBy">
+    <skos:definition>Resource that incorporates another resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Absorbed by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/absorbed"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/continuedBy">
+    <skos:definition>Resource whose content continues an earlier resource under a new title.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Continued by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/continues"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/continuedInPartBy">
+    <skos:definition>Resource part of whose content separated from an earlier resource to form a new resource.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/succeededBy"/>
+    <rdfs:comment>Used with Work or Instance</rdfs:comment>
+    <rdfs:label>Continued in part by</rdfs:label>
+    <rdfs:comment>Expected value Work or Instance</rdfs:comment>
+    <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/separatedFrom"/>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-29 (added inverse, updated range)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/contribution">
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Contribution"/>
+    <skos:definition>Agent and its role in relation to the resource.</skos:definition>
+    <rdfs:comment>Used with Work, Instance or Item</rdfs:comment>
+    <rdfs:label>Contributor and role</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Corrected label)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/role">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Contribution"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Role"/>
+    <skos:definition>Function provided by a contributor, e.g., author, illustrator, etc.</skos:definition>
+    <rdfs:label>Contributor role</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2017-02-03 (Changed from data to object property, adjusted label and definition)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/assigner">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Entity that assigned the metadata, such as the entity that assigned a classification number, entity that assigned a name, entity that assigned an identifier.</skos:definition>
+    <rdfs:label>Assigner</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/derivedFrom">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Link to the metadata that was the source of the data.</skos:definition>
+    <rdfs:label>Source metadata</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/changeDate">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date or date and time on which the metadata was modified.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/date"/>
+    <rdfs:label>Description change date</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/creationDate">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date or date and time on which the original metadata first created.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/date"/>
+    <rdfs:label>Description creation date</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/descriptionConventions">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/DescriptionConventions"/>
+    <skos:definition>Rules used for the descriptive content of the resource description.</skos:definition>
+    <rdfs:label>Description conventions</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+    <dcterms:modified>2016-04-24 (fixed domain name)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/descriptionLanguage">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Language"/>
+    <skos:definition>Language used for the metadata.</skos:definition>
+    <rdfs:label>Description language</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/generationProcess">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/GenerationProcess"/>
+    <skos:definition>Indication of the program or process used to generate the description by application of a particular transformation.</skos:definition>
+    <rdfs:label>Description generation</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/descriptionModifier">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Agent"/>
+    <skos:definition>Agency that modified a description.</skos:definition>
+    <rdfs:label>Description modifier</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://id.loc.gov/ontologies/bibframe/descriptionAuthentication">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"/>
+    <skos:definition>Indication of specific types of reviews that have been carried out on the description information.</skos:definition>
+    <rdfs:label>Description authentication</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://id.loc.gov/ontologies/bibframe/generationDate">
+    <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/AdminMetadata"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <skos:definition>Date of conversion of the metadata from another format.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://id.loc.gov/ontologies/bibframe/date"/>
+    <rdfs:label>Date generated</rdfs:label>
+    <dcterms:modified>2016-04-21 (New)</dcterms:modified>
+  </owl:DatatypeProperty>
+</rdf:RDF>

--- a/source/assets/rdfxml/mads-v1.rdf.xml
+++ b/source/assets/rdfxml/mads-v1.rdf.xml
@@ -1,0 +1,1403 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- from http://www.loc.gov/standards/mads/rdf/v1.rdf 2018-10-29 -->
+<rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+  xmlns="http://www.loc.gov/standards/mads/rdf/v1.rdf#">
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Address">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Address</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Affiliation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A resource that describes an individual's affiliation with an
+      organization or group, such as the nature of the affiliation and the active
+      dates.</rdfs:comment>
+    <rdfs:label xml:lang="en">Affiliation</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Area">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a non-jurisdictional geographic entity.</rdfs:comment>
+    <rdfs:label xml:lang="en">Area Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Authority">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A concept with a controlled
+      label.</rdfs:comment>
+    <rdfs:label xml:lang="en">Authority</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#City">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is an inhabited place incorporated as a city, town, etc.</rdfs:comment>
+    <rdfs:label xml:lang="en">City Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#CitySection">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a smaller unit within a populated place, e.g., a neighborhood, park, or
+      street.</rdfs:comment>
+    <rdfs:label xml:lang="en">City Section Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#ComplexSubject">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">The label of a madsrdf:ComplexSubject is the concatenation of labels
+      from two or more madsrdf:SimpleType descriptions, except that the combination of
+      madsrdf:SimpleType labels for the madsrdf:ComplexSubject does not meet the conditions to be
+      the label of a madsrdf:NameTitle resource or madsrdf:HierarchicalGeographic
+      resource.</rdfs:comment>
+    <rdfs:label xml:lang="en">Complex Subject Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#ComplexType">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">madsrdf:ComplexType is a resource whose label is the concatenation
+      of labels from two or more Authority descriptions or two or more Variant descriptions or some
+      combination of Authority and Variant descriptions, each of a
+      madsrdf:SimpleType.</rdfs:comment>
+    <rdfs:label xml:lang="en">Complex Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSType"/>
+    <owl:disjointUnionOf>
+      <rdf:Description>
+        <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic"/>
+        <rdf:rest>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#NameTitle"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </rdf:rest>
+      </rdf:Description>
+    </owl:disjointUnionOf>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+    <owl:equivalentClass>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+          >1</owl:cardinality>
+        <owl:onProperty rdf:resource="http://www.loc.gov/mads/rdf/v1#componentList"/>
+      </owl:Restriction>
+    </owl:equivalentClass>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#ConferenceName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents a conference name.</rdfs:comment>
+    <rdfs:label xml:lang="en">Conference Name Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Name"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Continent">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is one of seven large landmasses on Earth. These are: Asia, Africa, Europe, North
+      America, South America, Australia, and Antarctica.</rdfs:comment>
+    <rdfs:label xml:lang="en">Continent Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#CorporateName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is the name of a corporate entity, which may include political or ecclesiastical
+      entities.</rdfs:comment>
+    <rdfs:label xml:lang="en">Corporate Name Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Name"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Country">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a country, i.e. a political entity considered a country. </rdfs:comment>
+    <rdfs:label xml:lang="en">Country Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#County">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is the largest local administrative unit, e.g. Warwickshire, in a country, e.g.
+      England.</rdfs:comment>
+    <rdfs:label xml:lang="en">County Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#DateNameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date Name
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#NameElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A former
+      Authority.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deprecated
+      Authority</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Element">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">madsrdf:Element types
+      describe the various parts of labels.</rdfs:comment>
+    <rdfs:label xml:lang="en">Element</rdfs:label>
+    <owl:equivalentClass>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+          >1</owl:cardinality>
+        <owl:onProperty rdf:resource="http://www.loc.gov/mads/rdf/v1#elementValue"/>
+      </owl:Restriction>
+    </owl:equivalentClass>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#ExtraterrestrialArea">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is any extraterrestrial entity or space, including a solar system, a galaxy, a star
+      system, and a planet, including a geographic feature of an individual planet.</rdfs:comment>
+    <rdfs:label xml:lang="en">Extraterrestrial Area Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#FamilyName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents a family name.</rdfs:comment>
+    <rdfs:label xml:lang="en">Family Name Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Name"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#FamilyNameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Family Name
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#NameElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#FullNameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fullname Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#NameElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#GenreForm">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Describes a resource whose label is a genre or form term. Genre
+      terms for textual materials designate specific kinds of materials distinguished by the style
+      or technique of their intellectual contents; for example, biographies, catechisms, essays,
+      hymns, or reviews. Form terms designate historically and functionally specific kinds of
+      materials as distinguished by an examination of their physical character, characteristics of
+      their intellectual content, or the order of information within them; for example, daybooks,
+      diaries, directories, journals, memoranda, questionnaires, syllabi, or time sheets. In the
+      context of graphic materials, genre headings denote categories of material distinguished by
+      vantage point, intended purpose, characteristics of the creator, publication status, or method
+      of representation.</rdfs:comment>
+    <rdfs:label xml:lang="en">Genre/Form Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#GenreFormElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Genre/Form Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Geographic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Describes a resource whose label represents a geographic place or
+      feature, especially when a more precise geographic determination (City, Country, Region, etc.)
+      cannot be made.</rdfs:comment>
+    <rdfs:label xml:lang="en">Geographic Authority</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#GeographicElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Geographic Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#GivenNameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Given Name
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#NameElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A madsrdf:HierarchicalGeographic indicates that its label is the
+      concatenation of labels from a sequence of madsrdf:Geographic types taken from one of the
+      madsrdf:Geographic sub-classes such as madsrdf:City, madsrdf:Country, madsrdf:State,
+      madsrdf:Region, madsrdf:Area, etc. The madsrdf:Geographic resources that constitute the
+      madsrdf:HierarchicalGeographic should have a broader to narrower hierarchical relationship
+      between them.</rdfs:comment>
+    <rdfs:label xml:lang="en">Hierarchical Geographic Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Identifier">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A madsrdf:Identifier
+      resource describes an identifier by associating the identifier value with its type. To be used
+      to record identifiers for a resource in the absence of URIs.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Other Identifier</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Island">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a tract of land surrounded by water and smaller than a continent but is not itself a
+      separate country. </rdfs:comment>
+    <rdfs:label xml:lang="en">Island Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Language">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Describes a resource whose label represents a
+      language.</rdfs:comment>
+    <rdfs:label xml:lang="en">Language Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+    <owl:equivalentClass rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#LanguageElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Language Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#MADSCollection">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A madsrdf:Collection is an
+      organizational unit, members of which will have some form of intellectually unifying theme but
+      not to the extent that it defines an independent knowledge organization system. It aggregates
+      madsrdf:Authority descriptions or other madsrdf:MADSCollection resources.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MADS Collection</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#MADSScheme">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">MADS Scheme is an organizational unit that describes a knowledge
+      organization system. It aggregates madsrdf:Authority descriptions and/or
+      madsrdf:MADSCollection resources included in the knowledge organization system. Including a
+      madsrdf:MADSCollection within a madsrdf:MADSScheme should be done with care; when a
+      madsrdf:MADSCollection is part of a madsrdf:MADSScheme, then any madsrdf:Authority within that
+      madsrdf:MADSCollection is effectively also in the madsrdf:MADSScheme.</rdfs:comment>
+    <rdfs:label xml:lang="en">MADS Scheme</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#MADSType">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MADS Type</rdfs:label>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#MainTitleElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Main Title
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#TitleElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Name">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Describes a resource whose label represents a name, especially when
+      a more precise Name type (madsrdf:ConferenceName, masdrdf:FamilyName, etc.) cannot be
+      identified.</rdfs:comment>
+    <rdfs:label xml:lang="en">Name Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#NameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Name Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#NameTitle">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">The label of a madsrdf:NameTitle resource is the concatenation of a
+      label of a madsrdf:Name description and the label of a madsrdf:Title description. Both
+      description types (madsrdf:Name and madsrdf:Title) are of madsrdf:SimpleType
+      types.</rdfs:comment>
+    <rdfs:label xml:lang="en">Name/Title Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#NonSortElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Non-sort Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#TitleElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Occupation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents an occcupation.</rdfs:comment>
+    <rdfs:label xml:lang="en">Occupation Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#PartNameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Part Name
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#TitleElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#PartNumberElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Part Number
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#TitleElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#PersonalName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents a personal name.</rdfs:comment>
+    <rdfs:label xml:lang="en">Personal Name Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Name"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Province">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a first order political division, e.g. Ontario, within a country, e.g. Canada. </rdfs:comment>
+    <rdfs:label xml:lang="en">Province Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#RWO">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A madsrdf:RWO is an
+      abstract entity and identifies a Real World Object (RWO) identified by the label of a
+      madsrdf:Authority or madsrdf:DeprecatedAuthority.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Real World
+      Object</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Region">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is an area that has the status of a jurisdiction, usually incorporating more than one
+      first level jurisdiction. </rdfs:comment>
+    <rdfs:label xml:lang="en">Region Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#SimpleType">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">madsrdf:SimpleType is a resource with a label constituting a single
+      word or phrase.</rdfs:comment>
+    <rdfs:label xml:lang="en">Simple Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Source">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that represents
+      the source of information about another resource. madsrdf:Source is a type of
+      citation.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Source</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#State">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a first order political division, e.g. Montana, within a country, e.g.
+      U.S.</rdfs:comment>
+    <rdfs:label xml:lang="en">State Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#SubTitleElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Subtitle Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#TitleElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Temporal">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents a time-based notion.</rdfs:comment>
+    <rdfs:label xml:lang="en">Temporal Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#TemporalElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Temporal Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#TermsOfAddressNameElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Terms of Address
+      Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#NameElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Territory">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label is a geographical area belonging to or under the jurisdiction of a governmental
+      authority. </rdfs:comment>
+    <rdfs:label xml:lang="en">Territory Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Title">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents a title.</rdfs:comment>
+    <rdfs:label xml:lang="en">Title Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#TitleElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Title Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Topic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Describes a resource whose
+      label represents a topic.</rdfs:comment>
+    <rdfs:label xml:lang="en">Topic Type</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#SimpleType"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#TopicElement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Topic Element</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.loc.gov/mads/rdf/v1#Variant">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A resource whose label is the alternate form of an Authority or
+      Deprecated Authority.</rdfs:comment>
+    <rdfs:label xml:lang="en">Variant</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <owl:disjointWith rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+  </owl:Class>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#adminMetadata">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">This relates an Authority or Variant to its administrative metadata,
+      which is, minimimally, a Class defined outside of the MADS/RDF namespace. The RecordInfo Class
+      from the RecordInfo ontology is recommended.</rdfs:comment>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority"/>
+                <rdf:rest>
+                  <rdf:Description>
+                    <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+                    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+                  </rdf:Description>
+                </rdf:rest>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
+    <rdfs:label xml:lang="en">Administrative Metadata</rdfs:label>
+  </owl:ObjectProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#activityEndDate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Latest date in a period of activity.
+    </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Activity End</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#activityStartDate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Earliest date in a period of activity.
+    </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Activity Start</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#affiliationEnd">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The date an individual
+      ceased to be affiliated with an organization.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Affiliation
+      Ended</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#affiliationStart">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The date an individual
+      established an affiliation with an organization.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Affiliation
+      Started</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#associatedLanguage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Language that a person,
+      organization, or family uses for publication, communication, etc., or in which a work is
+      expressed. </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Language"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Associated
+      Language</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#associatedLocale">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A town, city, province,
+      state, and/or country associated with persons, corporate bodies, families, works, and
+      expressions.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Associated Locale</rdfs:label>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#authoritativeLabel">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">A lexical string representing a controlled, curated label for the
+      Authority.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:label xml:lang="en">Authoritative Label</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+  </owl:AnnotationProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#birthDate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The year a person was born.
+      Date of birth may also include the month and day of the person’s birth. (RDA
+      9.3.2.1)</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Birth Date</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#birthPlace">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The town, city, province,
+      state, and/or country in which a person was born.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Place of Birth</rdfs:label>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#changeNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">A note detailing a modification to an Authority or
+      Variant.</rdfs:comment>
+    <rdfs:label xml:lang="en">Change Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#note"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#changeNote"/>
+  </owl:AnnotationProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#citationNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">A note about how the madsrdf:Source relates to the resource about
+      which the madsrdf:Source is the information source.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Source"/>
+    <rdfs:label xml:lang="en">Citation Note</rdfs:label>
+  </owl:AnnotationProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#citationSource">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">The cited resource.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Source"/>
+    <rdfs:label xml:lang="en">Citation Source</rdfs:label>
+  </owl:AnnotationProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#citationStatus">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">Should use a standard term - such as 'found' or 'not found' - to
+      indicate whether the cited resource yielded information about the resource related to the
+      madsrdf:Source.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Source"/>
+    <rdfs:label xml:lang="en">Citation Status</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+  </owl:DatatypeProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#city">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">The city component of an address.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+    <rdfs:label xml:lang="en">City</rdfs:label>
+  </owl:AnnotationProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#classification">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">The classification code associated with a
+      madsrdf:Authority.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:label xml:lang="en">Classification</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#semanticRelation"/>
+  </owl:AnnotationProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#code">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A code is a string of
+      characters associated with a the authoritative or deprecated label. It may record an
+      historical notation once used to uniquely identify a concept.</rdfs:comment>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Code</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#componentList">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">madsrdf:componentList
+      organizes the madsrdf:SimpleType resources whose labels are represented in the label of the
+      associated madsrdf:ComplexType resource.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexType"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Component List</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#country">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Country associated with an
+      address.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Country</rdfs:label>
+  </owl:AnnotationProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#creationDateEnd">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ending date of the date range for which the beginning date is recorded in madsrdf:creationDateStart.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#creationDateStart">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">For a work, earliest date (normally the year) associated with a work; that date may be the date the work was created or first published or released. For an expression, the earliest date (normally the year) associated with an expression; that date may be the date of the earliest known manifestation of that expression. In both cases the date may be the starting date of a range or a single date.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Work begun</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#deathDate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The year a person died.
+      Date of death may also include the month and day of the person’s death. (RDA
+      9.3.3.1)</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Death Date</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#deathPlace">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The town, city, province,
+      state, and/or country in which a person died.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Place of Death</rdfs:label>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#definitionNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">An explanation of the meaning of an Authority, DeprecatedAuthority,
+      or Variant description.</rdfs:comment>
+    <rdfs:label xml:lang="en">Definition Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#note"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+  </owl:AnnotationProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#deletionNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A note pertaining to the
+      deletion of a resource.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deletion Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#changeNote"/>
+  </owl:AnnotationProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#deprecatedLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A label once considered
+      authoritative (controlled and curated) but which is no longer.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deprecated Label</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#hiddenLabel"/>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#editorialNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A note pertaining to the
+      management of the label associated with the resource.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Editorial Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#note"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#editorialNote"/>
+  </owl:AnnotationProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#elementList">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">The madsrdf:elementList property is used to organize the various
+      parts of labels.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Element List</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#elementValue">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Element"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Element Value</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#email">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Email</rdfs:label>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#entityDescriptor">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any attribute that serves
+      to characterize a person, family or corporate body or that may be needed for differentiation
+      from other persons. families or corporate bodies and for which separate content designation is
+      not already defined.Or </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Entity
+      Descriptor</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#establishDate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The year a corporate body was established. Date of establishment may also include the month and day of the corporate body’s establishment.
+    </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Established</rdfs:label>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#exampleNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A example of how the
+      resource might be used.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#note"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#example"/>
+  </owl:AnnotationProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#extendedAddress">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The second address line, if
+      needed.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Extended Address</rdfs:label>
+  </owl:DatatypeProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#extension">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Extension</rdfs:label>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#fax">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fax number</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fax</rdfs:label>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#fieldOfActivity">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The field of activity
+      associated with an individual.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Field of
+      Activity</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#fullerName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Full form of name needed to
+      distinguish a person from another person with the same preferred name.</rdfs:comment>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#PersonalName"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fuller Name</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#gender">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DataTypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The gender with which a
+      person identifies. </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gender</rdfs:label>
+  </rdf:Property>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasAbbreviationVariant">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Abbreviation
+      Variant</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasVariant"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasAcronymVariant">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Acronym
+      Variant</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasVariant"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasAffiliation">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Property to associate an
+      individual, such as a foaf:Agent, to a group or organization with which an individual is or
+      has been affiliated.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Affiliation</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasAffiliationAddress">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The address of the group or
+      organization with which an individual is associated.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Affiliation
+      Address</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Broader
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#broader"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasBroaderExternalAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Creates a direct
+      relationship between an Authority and a more broadly defined Authority from a different MADS
+      Scheme.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Broader External
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#broadMatch"/>
+  </owl:ObjectProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#hasChararacteristic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A term that specifies a characteristic that differentiates a work or expression from another one.
+    </rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Other characteristic</rdfs:label>
+  </rdf:Property>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasCloseExternalAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Records a relationship
+      between an Authority and one that is closely related from a different MADS
+      Scheme.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Close External
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#closeMatch"/>
+  </owl:ObjectProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#hasCorporateParentAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Establishes a relationship
+      between a CorporateName Authority and one of the same that is more broadly
+      defined.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Parent
+      Organization</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"/>
+  </rdf:Property>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasCorporateSubsidiaryAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Establishes a relationship
+      between a CorporateName Authority and one of the same that is more narrowly
+      defined.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Is Parent Organization
+      Of</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasCorporateParentAuthority"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasEarlierEstablishedForm">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Used to reference a resource that was an earlier form. This is
+      Related type='earlier' in MADS XML.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Earlier Established
+      Form</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#see"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasLaterEstablishedForm"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasExactExternalAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Records a relationship
+      between an Authority and one to which it matches exactly but from a different MADS
+      Scheme.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Exact External
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasCloseExternalAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#exactMatch"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasExpansionVariant">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Expansion
+      Variant</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasVariant"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasHiddenVariant">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">Use for variants that are searchable, but not necessarily for
+      display.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:label xml:lang="en">Has Hidden Variant</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2008/05/skos-xl#hiddenLabel"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasIdentifier">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Associates a resource with
+      a madsrdf:Identifier.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Identifier</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Identifier"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasLaterEstablishedForm">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">Use to reference the later form of a resource. This is Related
+      type='later' in MADS XML.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Later Established
+      Form</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#see"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasEarlierEstablishedForm"/>
+  </owl:ObjectProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#hasMADSCollectionMember">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Associates an Authority or other Collection with a
+      madsrdf:MADSCollection.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <rdfs:label xml:lang="en">Has MADSCollection Member</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#hasMADSSchemeMember">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Associates an Authority or Collection with a
+      madsrdf:MADSScheme.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has MADS Scheme
+      Member</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme"/>
+  </rdf:Property>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Creates a direct
+      relationship between an Authority and one that is more narrowly defined.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Narrower
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#narrower"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasNarrowerExternalAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Creates a direct
+      relationship between an Authority and a more narrowly defined Authority from a different MADS
+      Scheme.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Narrower External
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#narrowMatch"/>
+  </owl:ObjectProperty>
+  <owl:SymmetricProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasReciprocalAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+    <rdfs:comment xml:lang="en">Establishes a relationship between two Authority resources. It is
+      reciprocal, so the relationship must be shared. This is Related type='equivalent' in MADS
+      XML.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Reciprocal
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#related"/>
+  </owl:SymmetricProperty>
+  <owl:SymmetricProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasReciprocalExternalAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Establishes a relationship
+      between an Authority and one from a different MADS Scheme. It is reciprocal, so the
+      relationship must be shared.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Reciprocal External
+      Authority</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasReciprocalAuthority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#relatedMatch"/>
+  </owl:SymmetricProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Unless the relationship can be more specifically identified, use
+      'hasRelatedAuthority.'</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:label xml:lang="en">Has Related Authority</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#semanticRelation"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasSource">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment xml:lang="en">Associates a resource description with its Source.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Source</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Source"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasTopMemberOfMADSScheme">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an Authority
+      that is at the top of the hierarchy of authorities within the MADS Scheme.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Top Member of MADS
+      Scheme</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasMADSSchemeMember"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#hasTopConcept"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasTranslationVariant">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A Variant whose label
+      represents a translation of that of the authoritative label.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Translation
+      Variant</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasVariant"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hasVariant">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Associates a Variant with an Authority or Deprecrated Authority.
+      Unless the variant type can be more specifically identified, use 'hasVariant.'</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has Variant</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2008/05/skos-xl#altLabel"/>
+  </owl:ObjectProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#hiddenLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A label entered for
+      discovery purposes but not shown.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hidden Label</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2008/05/skos-xl#literalForm"/>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#historyNote">
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A note pertaining to the
+      history of the resource.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">History Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#note"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#historyNote"/>
+  </owl:AnnotationProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#honoraryTitle">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Designation indicative of
+      royalty, nobility, or ecclesiastical rank or office, or a term of address for a person of
+      religious vocation.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Honorary Title</rdfs:label>
+  </rdf:Property>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#hours">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hours</rdfs:label>
+  </owl:DatatypeProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#idScheme">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The scheme associated with
+      the identifier. For example, "LCCN" would be used when the Identifier Value (madsrdf:idValue)
+      is a LC Control Number.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Identifier"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifier
+      Scheme</rdfs:label>
+  </owl:AnnotationProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#idValue">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The value of the identifier
+      conforming to the Identifier Scheme syntax.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Identifier"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifier Value</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#identifiesRWO">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Associates a
+      madsrdf:Authority with the Real World Object that is the subject of the authority's
+      label.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies RWO</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/focus"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority"/>
+  </rdf:Property>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Associates a Real World
+      Object with its Authority description.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Is Identified By
+      Authority</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#identifiesRWO"/>
+  </owl:ObjectProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Associates a Collection with a madsrdf:Authority or another
+      madsrdf:MADSCollection.</rdfs:comment>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
+    <rdfs:label xml:lang="en">Is Member Of MADSCollection</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasMADSCollectionMember"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Is Member of MADS
+      Scheme</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#inScheme"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasMADSSchemeMember"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#isTopMemberOfMADSScheme">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a MADS Scheme in
+      which the Authority is at the top of the hierarchy.</rdfs:comment>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSCollection"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Is Top Member of MADS
+      Scheme</rdfs:label>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#MADSScheme"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#topConceptOf"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#hasTopMemberOfMADSScheme"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#natureOfAffiliation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Records the individual's
+      role or position in the organization with which the individual is affiliated. A "job title"
+      might be appropriate.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nature of
+      Affiliation</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#note">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A note about the
+      resource.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Note</rdfs:label>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#note"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#occupation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A profession or occupation
+      in which the person works or has worked.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Occupation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Occupation</rdfs:label>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#organization">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The group or organization
+      with which an individual is associated.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Organization or
+      Group</rdfs:label>
+  </owl:AnnotationProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#phone">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Affiliation"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phone</rdfs:label>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#postcode">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Post Code / Zip
+      Code</rdfs:label>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#prominentFamilyMember">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A well-known individual who
+      is a member of the family.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prominent Family
+      Member</rdfs:label>
+  </rdf:Property>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#scopeNote">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scope Note</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#note"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/2004/02/skos/core#scopeNote"/>
+  </owl:AnnotationProperty>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#see">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Denotes a relationship
+      between an Authority and/or DeprecatedAuthority. The relationship may or may or may not be
+      reciprocated and there is no certainty that the related resource will further illuminate the
+      original resource.</rdfs:comment>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">See Also</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+  </owl:ObjectProperty>
+  <owl:AnnotationProperty rdf:about="http://www.loc.gov/mads/rdf/v1#state">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The state associated with
+      an address.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">State</rdfs:label>
+  </owl:AnnotationProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#streetAddress">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">First line of address. For
+      second line, use madsrdf:extendedAddress.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Address"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Street Address</rdfs:label>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#terminateDate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The year a corporate body was terminated. Date of termination may also include the month and day of the corporate body’s termination.
+    </rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#RWO"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Terminated</rdfs:label>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#useFor">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">"Use [This Resource] For."
+      Traditional "USE FOR" reference.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use For</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#see"/>
+    <owl:inverseOf rdf:resource="http://www.loc.gov/mads/rdf/v1#useInstead"/>
+  </rdf:Property>
+  <owl:ObjectProperty rdf:about="http://www.loc.gov/mads/rdf/v1#useInstead">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">"Use [This Other Resource]
+      Instead." Traditional "USE" reference.</rdfs:comment>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use Instead</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.loc.gov/mads/rdf/v1#see"/>
+  </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:about="http://www.loc.gov/mads/rdf/v1#variantLabel">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The lexical, variant form
+      of an authoritative label.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.loc.gov/mads/rdf/v1#Variant"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Variant Label</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2008/05/skos-xl#literalForm"/>
+  </owl:DatatypeProperty>
+  <rdf:Property rdf:about="http://www.loc.gov/mads/rdf/v1#workOrigin">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The country or other territorial jurisdiction from which a work originated.</rdfs:comment>
+    <rdfs:range rdf:resource="http://www.loc.gov/mads/rdf/v1#Geographic"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Work locale</rdfs:label>
+  </rdf:Property>
+  <owl:Ontology rdf:about="http://www.loc.gov/standards/mads/rdf/v1.rdf">
+    <rdfs:comment xml:lang="en">Updated: 29 October 2015</rdfs:comment>
+  </owl:Ontology>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+  <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLSchema#date"/>
+  <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
+</rdf:RDF>

--- a/source/assets/rdfxml/rdf-schema.rdf.xml
+++ b/source/assets/rdfxml/rdf-schema.rdf.xml
@@ -1,0 +1,131 @@
+<!--  from https://www.w3.org/2000/01/rdf-schema.rdf 2018-10-29 -->
+<rdf:RDF
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+ <owl:Ontology
+     rdf:about="http://www.w3.org/2000/01/rdf-schema#"
+     dc:title="The RDF Schema vocabulary (RDFS)"/>
+
+<rdfs:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Resource">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>Resource</rdfs:label>
+  <rdfs:comment>The class resource, everything.</rdfs:comment>
+</rdfs:Class>
+
+<rdfs:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Class">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>Class</rdfs:label>
+  <rdfs:comment>The class of classes.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdfs:Class>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>subClassOf</rdfs:label>
+  <rdfs:comment>The subject is a subclass of a class.</rdfs:comment>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#subPropertyOf">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>subPropertyOf</rdfs:label>
+  <rdfs:comment>The subject is a subproperty of a property.</rdfs:comment>
+  <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>comment</rdfs:label>
+  <rdfs:comment>A description of the subject resource.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>label</rdfs:label>
+  <rdfs:comment>A human-readable name for the subject.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#domain">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>domain</rdfs:label>
+  <rdfs:comment>A domain of the subject property.</rdfs:comment>
+ <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#range">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>range</rdfs:label>
+  <rdfs:comment>A range of the subject property.</rdfs:comment>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>seeAlso</rdfs:label>
+  <rdfs:comment>Further information about the subject resource.</rdfs:comment>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:domain   rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+  <rdfs:label>isDefinedBy</rdfs:label>
+  <rdfs:comment>The defininition of the subject resource.</rdfs:comment>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdfs:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Literal">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>Literal</rdfs:label>
+  <rdfs:comment>The class of literal values, eg. textual strings and integers.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdfs:Class>
+
+<rdfs:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Container">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>Container</rdfs:label>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:comment>The class of RDF containers.</rdfs:comment>
+</rdfs:Class>
+
+<rdfs:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>ContainerMembershipProperty</rdfs:label>
+  <rdfs:comment>The class of container membership properties, rdf:_1, rdf:_2, ...,
+                    all of which are sub-properties of 'member'.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdfs:Class>
+
+<rdf:Property rdf:about="http://www.w3.org/2000/01/rdf-schema#member">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>member</rdfs:label>
+  <rdfs:comment>A member of the subject resource.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdfs:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Datatype">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+  <rdfs:label>Datatype</rdfs:label>
+  <rdfs:comment>The class of RDF datatypes.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+</rdfs:Class>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#">
+  <rdfs:seeAlso rdf:resource="http://www.w3.org/2000/01/rdf-schema-more"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/source/assets/rdfxml/rdf-syntax-ns.rdf.xml
+++ b/source/assets/rdfxml/rdf-syntax-ns.rdf.xml
@@ -1,0 +1,156 @@
+<!-- from https://www.w3.org/1999/02/22-rdf-syntax-ns.rdf 2018-10-29 -->
+<rdf:RDF
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+ <owl:Ontology
+     rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <dc:title>The RDF Concepts Vocabulary (RDF)</dc:title>
+   <dc:description>This is the RDF Schema for the RDF vocabulary terms in the RDF Namespace, defined in RDF 1.1 Concepts.</dc:description>
+ </owl:Ontology>
+
+<rdfs:Datatype rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML">
+   <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+   <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+   <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/rdf11-concepts/#section-html"/>
+   <rdfs:label>HTML</rdfs:label>
+   <rdfs:comment>The datatype of RDF literals storing fragments of HTML content</rdfs:comment>
+</rdfs:Datatype>
+
+<rdfs:Datatype rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString">
+   <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+   <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+   <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal"/>
+   <rdfs:label>langString</rdfs:label>
+   <rdfs:comment>The datatype of language-tagged string values</rdfs:comment>
+</rdfs:Datatype>
+
+ <rdfs:Datatype rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">
+   <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+   <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+   <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/rdf-plain-literal/"/>
+   <rdfs:label>PlainLiteral</rdfs:label>
+   <rdfs:comment>The class of plain (i.e. untyped) literal values, as used in RIF and OWL 2</rdfs:comment>
+</rdfs:Datatype>
+
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>type</rdfs:label>
+  <rdfs:comment>The subject is an instance of a class.</rdfs:comment>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdfs:Class rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>Property</rdfs:label>
+  <rdfs:comment>The class of RDF properties.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdfs:Class>
+
+<rdfs:Class rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>Statement</rdfs:label>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:comment>The class of RDF statements.</rdfs:comment>
+</rdfs:Class>
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>subject</rdfs:label>
+  <rdfs:comment>The subject of the subject RDF statement.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>predicate</rdfs:label>
+  <rdfs:comment>The predicate of the subject RDF statement.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#object">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>object</rdfs:label>
+  <rdfs:comment>The object of the subject RDF statement.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdfs:Class rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>Bag</rdfs:label>
+  <rdfs:comment>The class of unordered containers.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdfs:Class>
+
+<rdfs:Class rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>Seq</rdfs:label>
+  <rdfs:comment>The class of ordered containers.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdfs:Class>
+
+<rdfs:Class rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>Alt</rdfs:label>
+  <rdfs:comment>The class of containers of alternatives.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdfs:Class>
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#value">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>value</rdfs:label>
+  <rdfs:comment>Idiomatic property used for structured values.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<!-- the following are new additions, Nov 2002 -->
+
+<rdfs:Class rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>List</rdfs:label>
+  <rdfs:comment>The class of RDF Lists.</rdfs:comment>
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdfs:Class>
+
+<rdf:List rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>nil</rdfs:label>
+  <rdfs:comment>The empty list, with no items in it. If the rest of a list is nil then the list has no more items in it.</rdfs:comment>
+</rdf:List>
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#first">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>first</rdfs:label>
+  <rdfs:comment>The first item in the subject RDF list.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+  <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest">
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>rest</rdfs:label>
+  <rdfs:comment>The rest of the subject RDF list after the first item.</rdfs:comment>
+  <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+  <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+</rdf:Property>
+
+<rdfs:Datatype rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">
+  <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  <rdfs:isDefinedBy rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <rdfs:label>XMLLiteral</rdfs:label>
+  <rdfs:comment>The datatype of XML literal values.</rdfs:comment>
+</rdfs:Datatype>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdfs:seeAlso rdf:resource="http://www.w3.org/2000/01/rdf-schema-more"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/source/html/sinopiaProfileForm.html
+++ b/source/html/sinopiaProfileForm.html
@@ -50,7 +50,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button id="chooserClose" type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
-                <h3 class="modal-title">{{vocabHeader || "Chose Vocab Template"}}</h3>
+                <h3 class="modal-title">{{vocabHeader || "Choose Vocab Template"}}</h3>
             </div>
             <div class="modal-body">
                 <!--Put the select in a div so that ff styles it correctly-->

--- a/source/versoSpoof.js
+++ b/source/versoSpoof.js
@@ -42,3 +42,66 @@ function loadVocabs() {
     )
   }
 }
+
+// Manual construction of ontologies list, based on lcnetdev verso/server/boot/05-load-ontologies.js
+module.exports.ontologies = [
+  {
+    'id': 'Bibframe-ontology',
+    'configType': 'ontology',
+    'name': 'Bibframe-ontology',
+    'json': {'label': 'Bibframe 2.0', 'url': 'http://id.loc.gov/ontologies/bibframe.rdf'},
+  },
+  {
+    'id': 'BFLC-ontology',
+    'configType': 'ontology',
+    'name': 'BFLC-ontology',
+    'json': {'label': 'BFLC', 'url': 'http://id.loc.gov/ontologies/bflc.rdf'},
+  },
+  {
+    'id': 'MADSRDF-ontology',
+    'configType': 'ontology',
+    'name': 'MADSRDF-ontology',
+    'json': {'label': 'MADSRDF', 'url': 'http://www.loc.gov/standards/mads/rdf/v1.rdf'},
+  },
+  {
+    'id': 'RDF-ontology',
+    'configType': 'ontology',
+    'name': 'RDF-ontology',
+    'json': {'label': 'RDF', 'url': 'http://www.w3.org/1999/02/22-rdf-syntax-ns.rdf'},
+  },
+  {
+    'id': 'RDF-Schema-ontology',
+    'configType': 'ontology',
+    'name': 'RDF-Schema-ontology',
+    'json': {'label': 'RDFS', 'url': 'http://www.w3.org/2000/01/rdf-schema.rdf'},
+  }
+]
+
+var owlOntUrlToXmlMappings = []
+const owlOntUrl2FileMappings = [
+  {'url': 'http://id.loc.gov/ontologies/bibframe.rdf', 'fname': 'bibframe.rdf.xml'},
+  {'url': 'http://id.loc.gov/ontologies/bflc.rdf', 'fname': 'bflc.rdf.xml'},
+  {'url': 'http://www.loc.gov/standards/mads/rdf/v1.rdf', 'fname': 'mads-v1.rdf.xml'},
+  {'url': 'http://www.w3.org/1999/02/22-rdf-syntax-ns.rdf', 'fname': 'rdf-syntax-ns.rdf.xml'},
+  {'url': 'http://www.w3.org/2000/01/rdf-schema.rdf', 'fname': 'rdf-schema.rdf.xml'}
+]
+loadOwlOntologies()
+
+function loadOwlOntologies() {
+  const x2js = require('x2js')
+  const x2json_parser = new x2js()
+  if (owlOntUrlToXmlMappings.length == 0) {
+    owlOntUrl2FileMappings.forEach(function (mappingEl) {
+      const fileName = mappingEl['fname']
+      const filePath = path.join(__dirname, 'assets', 'rdfxml', fileName)
+      const oxml = fs.readFileSync(filePath, {encoding: 'utf8'})
+      owlOntUrlToXmlMappings.push(
+        {
+          url: mappingEl['url'],
+          'xml': oxml
+        }
+      )
+    })
+  }
+}
+module.exports.owlOntUrlToXmlMappings = owlOntUrlToXmlMappings


### PR DESCRIPTION
- also corrects typo in ontologies modal title ("Chose Vocab")

points to consider:  
- should ontologyUrls, that is computed in server.js, be instead another object made available via versoSpoof?
- where should the local copies of owl ontologies live?
- the `server/whichrt?` url is also used for `checkURI` validation of resource and property URIs.  This PR breaks that (if it ever worked).
- me editor changed some whitespace on blank lines in vocabService.js -- if we care, i will fix.

Closes #102