### PR TITLE
Updating merge version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6992,7 +6992,7 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true


### PR DESCRIPTION
Updated package-lock.json to use version 1.2.1 or greater following security update from Github