### PR TITLE
Adds CC 4.0 license to footer

### DIFF
--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -45,6 +45,7 @@ describe('Sinopia Profile Editor Homepage', () => {
   it('footer', async () => {
     await expect(page).toMatch('funded by the Andrew W. Mellon Foundation')
     await expect_value_in_selector_textContent('div.sinopia-footer > a', 'Linked Data for Production 2 (LD4P2)')
+    await expect_value_in_selector_textContent('div.sinopia-footer > a:nth-child(3)', 'Creative Commons Attribution 4.0 International License')
   })
 
   it('loads our angular app', async () => {

--- a/source/index.html
+++ b/source/index.html
@@ -111,7 +111,10 @@
                 </div>
 
                 <div class="sinopia-footer">
+                    <img alt="Creative Commons License" class="pull-left" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
                     Sinopia is a project of <a href="http://www.ld4p.org">Linked Data for Production 2 (LD4P2)</a>, funded by the Andrew W. Mellon Foundation.
+                    All content in Sinopia is licensed under a
+                    <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
                 </div>
 
             </div>


### PR DESCRIPTION
Includes text and graphic for adding Creative Commons 4.0 Attribution 4.0 International License to footer as requested by @astridu 

Fixes https://github.com/LD4P/sinopia/issues/116