### PR TITLE
Tests for checking URIs in UI

### DIFF
--- a/source/__tests__/integration/create-resource.test.js
+++ b/source/__tests__/integration/create-resource.test.js
@@ -52,9 +52,9 @@ describe('Create profile resource template requirements', () => {
         resourceURI: "htt",
       }).catch(error => console.log(`promise error for filling profile form: ${error}`));
       await page.waitFor(1000)
-      page
-        .waitForSelector('input#resourceURI.ng-invalid-url')
-        .catch(error => console.log(`promise error checkURL: ${error}`))
+      const invalid_url_class = page.$('input#resourceURI', e => e.getAttribute('ng-invalid-url'))
+      expect(invalid_url_class).toBeDefined()
+
       await page.click(exportButtonSel)
       page
         .waitForSelector(alertBoxSel)
@@ -107,14 +107,10 @@ describe('Create profile resource template requirements', () => {
           let dom = document.querySelector('a.propertyLink');
           dom.innerHTML = "h";
       });
-
-      const phtml = await page.evaluate(() => document.querySelector('a.propertyLink').innerHTML);
-      console.log(phtml)
-
-      console.log("PropertyURI Invalid")
-      page
-          .waitForSelector('input#propertyURI.ng-invalid-url')
-          .catch(error => console.log(`promise error checkPropertyURL: ${error}`))
+      await expect_value_in_sel_textContent('a.propertyLink', 'h')
+      await page.waitFor(2000)
+      const invalid_url_class = await page.$('input#propertyURI', e => e.getAttribute('ng-invalid-url'))
+      expect(invalid_url_class).toBeDefined()
     })
 
     it('valid property uri', async () => {
@@ -134,17 +130,12 @@ describe('Create profile resource template requirements', () => {
 
     await page.evaluate(() => {
         let dom = document.querySelector('a.propertyLink');
-    dom.innerHTML = "http://id.loc.gov/ontologies/bibframe/code";
+        dom.innerHTML = "http://id.loc.gov/ontologies/bibframe/code";
     });
 
-    const phtml = await page.evaluate(() => document.querySelector('a.propertyLink').innerHTML);
-    console.log(phtml)
-
-    console.log("PropertyURI Valid")
     page.waitFor(2000)
-    page
-        .waitForSelector('input#propertyURI.ng-valid-url')
-        .catch(error => console.log(`promise error checkPropertyURL: ${error}`))
+    const valid_url_class = page.$('input#propertyURI', e => e.getAttribute('ng-valid-url'))
+    expect(valid_url_class).toBeDefined()
     })
   })
 })
@@ -157,5 +148,3 @@ async function expect_value_in_sel_textContent(sel, value) {
   const sel_text = await page.$eval(sel, e => e.textContent)
   expect(sel_text).toBe(value)
 }
-
-

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -1,4 +1,5 @@
 describe('Adding and removing a new Profile', () => {
+    const source_input_sel = '#profile input[name="source"]'
 
     beforeAll(async () => {
         await page.goto('http://localhost:8000/#/profile/create/')
@@ -28,8 +29,6 @@ describe('Adding and removing a new Profile', () => {
 
     describe('Source url', () => {
 
-      const source_input_sel = '#profile input[name="source"]'
-
       it('source input label and field', async () => {
         await expect_value_in_selector_textContent('#profile label[for="source"]', 'Source')
         const input_name = await page.$eval(source_input_sel, e => e.getAttribute('name'))
@@ -41,21 +40,9 @@ describe('Adding and removing a new Profile', () => {
         await expect(popover).toBe('Link to more information about profile')
       })
 
-      it('with function checkURL', async () => {
+      it('validates with checkURL', async () => {
         const ng_blur = await page.$eval(source_input_sel, e => e.getAttribute('ng-blur'))
         await expect(ng_blur).toBe('checkURL()')
-      })
-
-      it('displays error if source and user switches focus', async () => {
-        await page
-          .type(source_input_sel, '')
-          .catch(error => console.log(`promise error for : ${error}`))
-        await page.keyboard.press(`Tab`)
-        await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-header > h3', 'Error!')
-        const invalid_url_class = page.$('input#resourceURI', e => e.getAttribute('ng-invalid-url'))
-        expect(invalid_url_class).toBeDefined()
-        await page.$eval("button#alertClose", e => e.click())
-        await page.waitFor(1000)
       })
 
     })
@@ -131,6 +118,20 @@ describe('Adding and removing a new Profile', () => {
             await expect(page).not.toMatch('span', { text: 'Resource Template' })
         })
     });
+
+    describe('Profile fields errors', () => {
+
+      it('displays error if source and user switches focus', async () => {
+        await page
+          .type(source_input_sel, '')
+          .catch(error => console.log(`promise error for : ${error}`))
+        await page.keyboard.press(`Tab`)
+        await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-header > h3', 'Error!')
+        const invalid_url_class = page.$('input#resourceURI', e => e.getAttribute('ng-invalid-url'))
+        expect(invalid_url_class).toBeDefined()
+      })
+
+    })
 
 });
 

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -52,6 +52,8 @@ describe('Adding and removing a new Profile', () => {
           .catch(error => console.log(`promise error for : ${error}`))
         await page.keyboard.press(`Tab`)
         await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-header > h3', 'Error!')
+        const invalid_url_class = page.$('input#resourceURI', e => e.getAttribute('ng-invalid-url'))
+        expect(invalid_url_class).toBeDefined()
         await page.$eval("button#alertClose", e => e.click())
         await page.waitFor(1000)
       })

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -41,19 +41,30 @@ describe('Adding and removing a new Profile', () => {
         await expect(popover).toBe('Link to more information about profile')
       })
 
-      it('validates with checkURL', async () => {
+      it('with function checkURL', async () => {
         const ng_blur = await page.$eval(source_input_sel, e => e.getAttribute('ng-blur'))
         await expect(ng_blur).toBe('checkURL()')
       })
+
+      it('displays error if source and user switches focus', async () => {
+        await page
+          .type(source_input_sel, '')
+          .catch(error => console.log(`promise error for : ${error}`))
+        await page.keyboard.press(`Tab`)
+        await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-header > h3', 'Error!')
+        await page.$eval("button#alertClose", e => e.click())
+        await page.waitFor(1000)
+      })
+
     })
 
     describe('Adding a Resource Template', () => {
 
-        beforeAll(async () => {
-            await page.waitForSelector('#addResource')
-            await page.click('#addResource')
-            await page.waitFor(1000)
-        })
+      beforeAll(async () => {
+          await page.waitForSelector('#addResource')
+          await page.click('#addResource')
+          await page.waitFor(1000)
+      })
 
         it('displays a new resource template span', async () => {
             const title = await page.$eval('span[id="0"] > span', e => e.getAttribute('popover-title'))


### PR DESCRIPTION
When investigating bug #134, created a new test when shifting focus from an empty `source` URL field in `new-profile.test.js`. Also updated the `create-resource.test.js` to test if the error classes or valid URI classes are present.