### PR TITLE
Updated merge node module to 1.2.1 to address a security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7026,9 +7026,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-descriptors": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "^23.6.0",
     "jest-junit": "^5.2.0",
     "jest-puppeteer": "^3.4.0",
+    "merge": "^1.2.1",
     "puppeteer": "^1.8.0"
   },
   "jest": {


### PR DESCRIPTION
From Github that allows a possible denial-of-service attack, see below:
https://nvd.nist.gov/vuln/detail/CVE-2018-16469


