### PR TITLE
Circle-ci Linting Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "scripts": {
     "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js source/assets/js/modules/help source/assets/js/modules/profile source/assets/js/ng-app.js",
     "dev-test": "npm install && npm run grunt-dev && jest --colors",
-    "eslint": "eslint --color --max-warnings 176 -c .eslintrc.js .",
+    "eslint": "eslint --color --max-warnings 172 -c .eslintrc.js .",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
     "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors",

--- a/source/__tests__/integration/profile-create.test.js
+++ b/source/__tests__/integration/profile-create.test.js
@@ -1,7 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
-const path = require('path')
-
 describe('Sinopia Profile Editor Create Page', () => {
   describe('Upload dialog not showing', () => {
     beforeAll(async () => {

--- a/source/assets/js/modules/profile/controllers/profile.controller.js
+++ b/source/assets/js/modules/profile/controllers/profile.controller.js
@@ -680,7 +680,7 @@ angular.module('locApp.modules.profile.controllers')
             }
           });
           return check;
-        };
+        }
       };
 
       $scope.propertyValid = function(property) {
@@ -698,7 +698,7 @@ angular.module('locApp.modules.profile.controllers')
             }
           });
           return check;
-        };
+        }
       };
 
       /*Created by -rsegura 12/10/2014


### PR DESCRIPTION
Fixed a couple of errors being thrown by eslint, should be under max-warnings of 172.  The circle-ci build was failing in the last merge to master because of eslint error and generating a docker-hub image for CI in AWS development environment.

  * Removed extra semi-colons in the `profile.controller.js` file 
  * Removed unneeded import statement in the `profile-create.test.js` file.