### PR TITLE
Can load v0.1.0 profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,10 @@
     "dev-test": "npm install && npm run grunt-dev && jest --colors",
     "eslint": "eslint --color --max-warnings 172 -c .eslintrc.js .",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
-    "jest-ci": "jest --coverage --ci --runInBand --reporters=default --reporters=jest-junit --colors && cat ./coverage/lcov.info | coveralls",
-    "jest-cov": "jest --coverage --colors",
-    "test": "jest --colors"
+    "jest-ci": "jest --coverage --colors --silent --ci --runInBand --reporters=default --reporters=jest-junit && cat ./coverage/lcov.info | coveralls",
+    "jest-cov": "jest --coverage --colors --silent",
+    "test": "jest --colors --silent",
+    "test-verbose": "jest --colors"
   },
   "engines": {
     "node": "10.11.x"

--- a/source/__tests__/__fixtures__/item_profile_lc_v0.0.2.json
+++ b/source/__tests__/__fixtures__/item_profile_lc_v0.0.2.json
@@ -59,8 +59,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
             "propertyLabel": "Held by"

--- a/source/__tests__/__fixtures__/place_profile_sinopia_v0.1.0.json
+++ b/source/__tests__/__fixtures__/place_profile_sinopia_v0.1.0.json
@@ -1,0 +1,43 @@
+{
+  "Profile": {
+    "resourceTemplates": [
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "lookup",
+            "valueConstraint": {
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/names",
+                "http://id.loc.gov/authorities/subjects"
+              ]
+            },
+            "propertyLabel": "Search LCNAF/LCSH",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "literal",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Record Place (if it does not appear above)",
+            "remark": "http://access.rdatoolkit.org/6.5.html"
+          }
+        ],
+        "id": "sinopia:resourceTemplate:bf2:Place",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+        "resourceLabel": "Place Associated with a Work",
+        "author": "NDMSO",
+        "date": "2017-05-13",
+        "schema": "https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json"
+      }
+    ],
+    "id": "sinopia:profile:bf2:Place",
+    "title": "BIBFRAME 2.0 Place",
+    "date": "2017-05-13",
+    "description": "Place Associated with a Resource",
+    "author": "NDMSO",
+    "schema": "https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json"
+  }
+}

--- a/source/__tests__/integration/export-profile.test.js
+++ b/source/__tests__/integration/export-profile.test.js
@@ -14,7 +14,7 @@ describe('Sinopia Profile Editor exports an edited profile', () => {
 
     beforeAll(async () => {
       const path = require('path')
-      const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item.json')
+      const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item_profile_lc_v0.0.2.json')
       await expect(page).toUploadFile(
         'input[type="file"]',
         bf_item_location,

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -8,26 +8,26 @@ describe('Importing a profile from a json file', () => {
 
   beforeAll(async () => {
     const path = require('path')
-    const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item.json')
+    const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item_profile_lc_v0.0.2.json')
     await expect(page).toUploadFile(
         'input[type="file"]',
         bf_item_location,
     )
   })
 
-  it('imports an existing profile and resource templates', async () => {
+  it('imports an existing v0.0.2 profile and resource templates', async () => {
     await page.waitForSelector('span[popover-title="Profile ID: profile:bf2:Item"]')
-        .then(async () => {
-          await expect_regex_in_sel_textContent('span[popover-title="Profile ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Access"]', 'Lending or Access Policy')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Use"]', 'Use or Reproduction Policy')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Retention"]', 'Retention Policy')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:ImmAcqSource"]', 'Immediate Source of Acquisition')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Enumeration"]', 'Enumeration')
-          await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Chronology"]', 'Chronology')
-        })
-        .catch(error => console.log(`promise error for import profile: ${error}`))
+      .then(async () => {
+        await expect_regex_in_sel_textContent('span[popover-title="Profile ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Access"]', 'Lending or Access Policy')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Use"]', 'Use or Reproduction Policy')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Retention"]', 'Retention Policy')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:ImmAcqSource"]', 'Immediate Source of Acquisition')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Enumeration"]', 'Enumeration')
+        await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Chronology"]', 'Chronology')
+      })
+      .catch(error => console.log(`promise error for import profile: ${error}`))
   })
 
   it('has the expected resource metadata and property sections', async() => {

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -1,13 +1,11 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const path = require('path')
 
 describe('Importing a profile from a json file', () => {
 
   beforeAll(async () => {
     await page.goto('http://localhost:8000/#/profile/create/true')
-  })
 
-  beforeAll(async () => {
-    const path = require('path')
     const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'item_profile_lc_v0.0.2.json')
     await expect(page).toUploadFile(
         'input[type="file"]',
@@ -27,7 +25,7 @@ describe('Importing a profile from a json file', () => {
         await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Enumeration"]', 'Enumeration')
         await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Chronology"]', 'Chronology')
       })
-      .catch(error => console.log(`promise error for import profile: ${error}`))
+      .catch(error => console.log(`promise error for import v0.0.2 profile: ${error}`))
   })
 
   it('has the expected resource metadata and property sections', async() => {
@@ -144,6 +142,22 @@ describe('Importing a profile from a json file', () => {
     // TODO: write this test
   })
 
+})
+
+it('imports an existing v0.1.0 profile and resource templates', async () => {
+  await page.goto('http://localhost:8000/#/profile/create/true')
+
+  const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'place_profile_sinopia_v0.1.0.json')
+  await expect(page).toUploadFile(
+    'input[type="file"]',
+    bf_item_location,
+  )
+  await page.waitForSelector('span[popover-title="Profile ID: sinopia:profile:bf2:Place"]')
+    .then(async () => {
+      await expect_regex_in_sel_textContent('span[popover-title="Profile ID: sinopia:profile:bf2:Place"]', 'BIBFRAME 2.0 Place')
+      await expect_regex_in_sel_textContent('span[popover-title="Resource ID: sinopia:resourceTemplate:bf2:Place"]', 'Place Associated with a Work')
+    })
+    .catch(error => console.log(`promise error for import v0.1.0 profile: ${error}`))
 })
 
 async function expect_regex_in_sel_textContent(sel, value) {

--- a/source/assets/js/modules/profile/services/profileHandler.service.js
+++ b/source/assets/js/modules/profile/services/profileHandler.service.js
@@ -12,7 +12,7 @@ angular.module('locApp.modules.profile.services')
         handler.errors = [];
 
         var profAttributes = ["id","title","description","date","author","remark","adherence","schema","resourceTemplates", "source"];
-        var resAttributes = ["id","resourceURI","resourceURL","resourceLabel","propertyTemplates","author","remark","schema"];
+        var resAttributes = ["id","resourceURI","resourceURL","resourceLabel","propertyTemplates","author","date","remark","schema"];
         var propAttributes = ["propertyURI","propertyLabel","mandatory","repeatable","type","valueConstraint","remark", "resourceTemplates"];
         var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults", "validatePattern"];
         var dataAttributes = ["dataTypeURI","dataTypeLabel","dataTypeLabelHint","remark"];

--- a/source/assets/js/modules/profile/services/profileHandler.service.js
+++ b/source/assets/js/modules/profile/services/profileHandler.service.js
@@ -12,7 +12,7 @@ angular.module('locApp.modules.profile.services')
         handler.errors = [];
 
         var profAttributes = ["id","title","description","date","author","remark","adherence","schema","resourceTemplates", "source"];
-        var resAttributes = ["id","resourceURI","resourceURL","resourceLabel","propertyTemplates","author","date","remark","schema"];
+        var resAttributes = ["id","resourceURI","resourceLabel","propertyTemplates","author","date","remark","schema","adherence","source"];
         var propAttributes = ["propertyURI","propertyLabel","mandatory","repeatable","type","valueConstraint","remark", "resourceTemplates"];
         var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults", "validatePattern"];
         var dataAttributes = ["dataTypeURI","dataTypeLabel","dataTypeLabelHint","remark"];
@@ -24,7 +24,6 @@ angular.module('locApp.modules.profile.services')
         var ID = "id";
         var TITLE = "title";
         var RESOURCE_URI = "resourceURI";
-        var RESOURCE_URL = "resourceURL";
         var PROPERTY_URI = "propertyURI";
 
         /**
@@ -110,7 +109,7 @@ angular.module('locApp.modules.profile.services')
         _resourceValidation= function(resourceTemplate,name) {
             //Check that the resource template has a resource URI and
             //at least one property template
-            if(!(RESOURCE_URI in resourceTemplate || RESOURCE_URL in resourceTemplate) || resourceTemplate[RESOURCE_URI] === undefined || resourceTemplate[RESOURCE_URI] === "") {
+            if(!(RESOURCE_URI in resourceTemplate) || resourceTemplate[RESOURCE_URI] === undefined || resourceTemplate[RESOURCE_URI] === "") {
                 handler.errors.push( name + " must have a resource URI field");
             }
             if(!(PROPERTY_TEMPLATE in resourceTemplate) || resourceTemplate[PROPERTY_TEMPLATE] === undefined || resourceTemplate[PROPERTY_TEMPLATE].length < 1) {


### PR DESCRIPTION
v0.1.0 profiles can now be imported.

- ensured all fields known to JSON schema are allowed on import
- removed a bogus field name (doesn't appear in any profile)
- tweaked a fixture name
- suppress console log messages by default on tests

Fixes #193