### PR TITLE
indicate required fields with asterisk

### DIFF
--- a/source/__tests__/integration/create-property.test.js
+++ b/source/__tests__/integration/create-property.test.js
@@ -66,27 +66,62 @@ describe('Create profile property template requirements', () => {
       })
     })
 
-    // it('displays the correct text for remark', async () => {
-    //   const sel = 'div.propertyItem label[for="remark"]'
-    //   await expect_value_in_sel_text(sel, 'Guiding statement for the use of this property')
-    // })
+    describe('valueConstraints fields', () => {
+      let vcFieldsTableSel = 'div[ng-controller="ValueConstraintController"]'
 
-    describe('Templates dropdown', () => {
-      it('populated with resource template ids (via profiles from versoSpoof)', async () => {
-        await page.waitForSelector(propTemplateSelectSelector)
-        const profile_count = await page.$eval(propTemplateSelectSelector, e => e.length)
-        expect(profile_count).toBe(235)
+      describe('Value Constraints', () => {
+        it('header', async () => {
+          await expect_value_in_sel_text(`${vcFieldsTableSel} > #constraintHeader`, "Value Constraint")
+        })
+        it('has no input fields', async () => {
+          const inputs = await page.$eval(`${vcFieldsTableSel} > table`, e => e.getElementsByTagName('input').length)
+          expect(inputs).toBe(0)
+        });
+        it('has no select fields', async () => {
+          const selects = await page.$eval(`${vcFieldsTableSel} > table`, e => e.getElementsByTagName('select').length)
+          expect(selects).toBe(0)
+        })
+        it('has Add Default Link', async () => {
+          await expect_value_in_sel_text(`${vcFieldsTableSel} > a#addDefault`, "Add Default")
+        })
       })
-      it('allows selection of a resource template id', async () => {
-        await page.waitForSelector(propTemplateSelectSelector)
-        // NOTE: the html always shows the first option selected, though the browser
-        //  shows the right thing.  So here we cheat and use indirect checking of attributes
-        //  to show a template can be selected
-        await expect_sel_to_exist(`${propTemplateSelectSelector}.ng-pristine`)
-        await expect_sel_to_exist(`${propTemplateSelectSelector} > option[selected="selected"][value="?"]`)
-        await page.select(propTemplateSelectSelector, 'profile:bf2:Form')
-        await expect_sel_to_exist(`${propTemplateSelectSelector}.ng-dirty`)
-        await expect_sel_to_exist(`${propTemplateSelectSelector} > option[selected="selected"][value^="profile:bf2"]`)
+
+
+      describe('Value Data Type', () => {
+        let vdtTableSel = `${vcFieldsTableSel} div[ng-controller="ValueDataTypeController"]`
+        it('header', async () => {
+          await expect(page).toMatch('Value Data Type')
+        })
+        it('has one input field', async () => {
+          const inputs = await page.$eval(vdtTableSel, e => e.getElementsByTagName('input').length)
+          expect(inputs).toBe(1)
+        })
+        it('has URI field', async () => {
+          await expect_value_in_sel_text(`${vdtTableSel} label[for="dataTypeURI"]`, "URI")
+        })
+      })
+
+      describe('Templates dropdown', () => {
+        it('populated with resource template ids (via profiles from versoSpoof)', async () => {
+          await page.waitForSelector(propTemplateSelectSelector)
+          const profile_count = await page.$eval(propTemplateSelectSelector, e => e.length)
+          expect(profile_count).toBe(235)
+        })
+        it('allows selection of a resource template id', async () => {
+          await page.waitForSelector(propTemplateSelectSelector)
+          // NOTE: the html always shows the first option selected, though the browser
+          //  shows the right thing.  So here we cheat and use indirect checking of attributes
+          //  to show a template can be selected
+          await expect_sel_to_exist(`${propTemplateSelectSelector}.ng-pristine`)
+          await expect_sel_to_exist(`${propTemplateSelectSelector} > option[selected="selected"][value="?"]`)
+          await page.select(propTemplateSelectSelector, 'profile:bf2:Form')
+          await expect_sel_to_exist(`${propTemplateSelectSelector}.ng-dirty`)
+          await expect_sel_to_exist(`${propTemplateSelectSelector} > option[selected="selected"][value^="profile:bf2"]`)
+        })
+      })
+
+      describe('has Add Value link', async () => {
+        await expect_value_in_sel_text(`${vcFieldsTableSel} > a#adValue`, "Add Value")
       })
     })
   })
@@ -196,7 +231,7 @@ async function expect_sel_to_exist(sel) {
 }
 async function expect_value_in_sel_text(sel, value) {
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  expect(sel_text.trim()).toBe(value)
 }
 async function expect_value_not_in_sel_text(sel, value) {
   const sel_text = await page.$eval(sel, e => e.textContent)

--- a/source/__tests__/integration/create-resource.test.js
+++ b/source/__tests__/integration/create-resource.test.js
@@ -20,12 +20,39 @@ describe('Create profile resource template requirements', () => {
   let alertBoxSel = '#alertBox > div > div > div.modal-body > p'
 
   describe('resource template form fields', () => {
+    const rt_fields_table_sel = 'div[id="resourceTemplates_0"] div.panel-body > table'
 
     it('appends a resource template section to the form', async () => {
-      page
-        .waitForSelector('span[id="0"] > span')
+      page.waitForSelector('span[id="0"] > span')
         .catch(error => console.log(`promise error for loading create page with import dialog: ${error}`))
       await expect_regex_in_sel_textContent('span[id="0"] > span', /^Resource Template\s*$/)
+    })
+
+    it('has five input fields for the resource template data', async () => {
+      const inputs = await page.$eval(rt_fields_table_sel, e => e.getElementsByTagName('input').length)
+      expect(inputs).toBe(5)
+    })
+
+    describe('Required fields are indicated with asterisk', async () => {
+      it('ID', async () => {
+        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="id"]`, "ID*")
+      })
+      it('Resource URI', async () => {
+        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="resourceURI"]`, "Resource URI*")
+      })
+      it('Resource Label', async () => {
+        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="resourceLabel"]`, "Resource Label*")
+      })
+      it('Author', async () => {
+        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="rtAuthor"]`, "Author*")
+      })
+    })
+
+    describe('Non-required fields have no asterisk', async () => {
+      it('Remark', async () => {
+        await expect_value_not_in_sel_textContent(`${rt_fields_table_sel} label[for="rtRemark"]`, "Guiding statement for the use of this resource*")
+        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="rtRemark"]`, "Guiding statement for the use of this resource")
+      })
     })
 
     it('requires Resource ID', async () => {
@@ -149,4 +176,8 @@ async function expect_regex_in_sel_textContent(sel, value) {
 async function expect_value_in_sel_textContent(sel, value) {
   const sel_text = await page.$eval(sel, e => e.textContent)
   expect(sel_text).toBe(value)
+}
+async function expect_value_not_in_sel_textContent(sel, value) {
+  const sel_text = await page.$eval(sel, e => e.textContent)
+  expect(sel_text.trim()).not.toBe(value)
 }

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -12,6 +12,52 @@ describe('Adding and removing a new Profile', () => {
     await expect(span).toMatch(/Profile ID: Undefined/)
   })
 
+  describe('Profile fields', () => {
+    const profile_fields_table_sel = 'div[id="profile"] > div.panel-body > table'
+
+    beforeAll(async () => {
+      await page.waitForSelector(profile_fields_table_sel)
+    })
+
+    it('has eight input fields for the profile admin data', async () => {
+      const inputs = await page.$eval(profile_fields_table_sel, e => e.getElementsByTagName('input').length)
+      expect(inputs).toBe(8)
+    })
+
+    describe('Required fields are indicated with asterisk', async () => {
+      it('ID', async () => {
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="id"]`, "ID*")
+      })
+      it('Description', async () => {
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="description"]`, "Description*")
+      })
+      it('Author', async () => {
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="author"]`, "Author*")
+      })
+      it('Title', async () => {
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="title"]`, "Title*")
+      })
+    })
+    it('Date has no asterisk b/c it may be filled in automagically', async () => {
+      await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="date"]`, "Date*")
+      await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="date"]`, "Date")
+    })
+    describe('Non-required fields have no asterisk', async () => {
+      it('Remark', async () => {
+        await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="remark"]`, "Remark*")
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="remark"]`, "Remark")
+      })
+      it('Adherence', async () => {
+        await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="adherence"]`, "Adherence*")
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="adherence"]`, "Adherence")
+      })
+      it('Source', async () => {
+        await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="source"]`, "Source*")
+        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="source"]`, "Source")
+      })
+    })
+  })
+
   describe('Adherence rules/standards that profile confirms with', () => {
 
     const adherence_input_sel = '#profile input[name="adherence"]'
@@ -62,19 +108,6 @@ describe('Adding and removing a new Profile', () => {
       expect(span).toMatch(/Resource Template/)
     })
 
-    it('has eight input fields for the profile admin data', async () => {
-      const inputs = await page.$eval('div[id="profile"] > div > table', e => e.getElementsByTagName('input').length)
-      expect(inputs).toBe(8)
-      await expect(page).toMatch('ID')
-      await expect(page).toMatch('Description')
-      await expect(page).toMatch('Contact')
-      await expect(page).toMatch('Title')
-      await expect(page).toMatch('Date')
-      await expect(page).toMatch('Remark')
-      await expect(page).toMatch('Adherence')
-      await expect(page).toMatch('Source')
-    })
-
     it('has five input fields for the resource template data', async () => {
       const inputs = await page.$eval('div[id="resource_0"] > div > table', e => e.getElementsByTagName('input').length)
       expect(inputs).toBe(5)
@@ -93,6 +126,7 @@ describe('Adding and removing a new Profile', () => {
     })
 
     it('now has 3 input fields for property ID once a resource template is added', async () => {
+      await page.waitForSelector('div[id="property_1"] > div > table')
       const inputs = await page.$eval('div[id="property_1"] > div > table', e => e.getElementsByTagName('input').length)
       expect(inputs).toBe(3)
       await page.waitFor(1000)
@@ -138,5 +172,10 @@ describe('Adding and removing a new Profile', () => {
 
 async function expect_value_in_selector_textContent(sel, value) {
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  expect(sel_text.trim()).toBe(value)
+}
+
+async function expect_value_not_in_selector_textContent(sel, value) {
+  const sel_text = await page.$eval(sel, e => e.textContent)
+  expect(sel_text.trim()).not.toBe(value)
 }

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -1,141 +1,140 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 describe('Adding and removing a new Profile', () => {
-    const source_input_sel = '#profile input[name="source"]'
+  const source_input_sel = '#profile input[name="source"]'
+
+  beforeAll(async () => {
+    await page.goto('http://localhost:8000/#/profile/create/')
+  })
+
+  it('displays a new profile span', async () => {
+    const span = await page.$eval('span[id="profileBanner"] > span', e => e.getAttribute('popover-title'))
+    await expect(span).toMatch(/Profile ID: Undefined/)
+  })
+
+  describe('Adherence rules/standards that profile confirms with', () => {
+
+    const adherence_input_sel = '#profile input[name="adherence"]'
+
+    it('adherence input label and field', async () => {
+      await expect_value_in_selector_textContent('#profile label[for="adherence"]', 'Adherence')
+      const field = await page.$eval(adherence_input_sel, e => e.getAttribute('name'))
+      await expect(field).toBe('adherence')
+    })
+
+    it('popover text', async () => {
+      const popover = await page.$eval(adherence_input_sel, e => e.getAttribute('popover'))
+      await expect(popover).toBe('What rules this profile follows')
+    })
+  })
+
+  describe('Source url', () => {
+
+    it('source input label and field', async () => {
+      await expect_value_in_selector_textContent('#profile label[for="source"]', 'Source')
+      const input_name = await page.$eval(source_input_sel, e => e.getAttribute('name'))
+      await expect(input_name).toBe('source')
+    })
+
+    it('popover text', async () => {
+      const popover = await page.$eval(source_input_sel, e => e.getAttribute('popover'))
+      await expect(popover).toBe('Link to more information about profile')
+    })
+
+    it('validates with checkURL', async () => {
+      const ng_blur = await page.$eval(source_input_sel, e => e.getAttribute('ng-blur'))
+      await expect(ng_blur).toBe('checkURL()')
+    })
+  })
+
+  describe('Adding a Resource Template', () => {
 
     beforeAll(async () => {
-        await page.goto('http://localhost:8000/#/profile/create/')
+      await page.waitForSelector('#addResource')
+      await page.click('#addResource')
+      await page.waitFor(1000)
     })
 
-    it('displays a new profile span', async () => {
-        const span = await page.$eval('span[id="profileBanner"] > span', e => e.getAttribute('popover-title'))
-        await expect(span).toMatch(/Profile ID: Undefined/)
+    it('displays a new resource template span', async () => {
+      const title = await page.$eval('span[id="0"] > span', e => e.getAttribute('popover-title'))
+      const span = await page.$eval('span[id="0"] > span', e => e.textContent)
+      expect(title).toMatch(/Resource ID: Undefined/)
+      expect(span).toMatch(/Resource Template/)
     })
 
-    describe('Adherence rules/standards that profile confirms with', () => {
-
-      const adherence_input_sel = '#profile input[name="adherence"]'
-
-      it('adherence input label and field', async () => {
-        await expect_value_in_selector_textContent('#profile label[for="adherence"]', 'Adherence')
-        const field = await page.$eval(adherence_input_sel, e => e.getAttribute('name'))
-        await expect(field).toBe('adherence')
-      })
-
-      it('popover text', async () => {
-        const popover = await page.$eval(adherence_input_sel, e => e.getAttribute('popover'))
-        await expect(popover).toBe('What rules this profile follows')
-      })
-
+    it('has eight input fields for the profile admin data', async () => {
+      const inputs = await page.$eval('div[id="profile"] > div > table', e => e.getElementsByTagName('input').length)
+      expect(inputs).toBe(8)
+      await expect(page).toMatch('ID')
+      await expect(page).toMatch('Description')
+      await expect(page).toMatch('Contact')
+      await expect(page).toMatch('Title')
+      await expect(page).toMatch('Date')
+      await expect(page).toMatch('Remark')
+      await expect(page).toMatch('Adherence')
+      await expect(page).toMatch('Source')
     })
 
-    describe('Source url', () => {
+    it('has five input fields for the resource template data', async () => {
+      const inputs = await page.$eval('div[id="resource_0"] > div > table', e => e.getElementsByTagName('input').length)
+      expect(inputs).toBe(5)
+      await expect(page).toMatch('ID')
+      await expect(page).toMatch('Resource Label')
+      await expect(page).toMatch('Guiding statement for the use of this resource')
+      await expect(page).toMatch('Resource URI')
+    })
+  })
 
-      it('source input label and field', async () => {
-        await expect_value_in_selector_textContent('#profile label[for="source"]', 'Source')
-        const input_name = await page.$eval(source_input_sel, e => e.getAttribute('name'))
-        await expect(input_name).toBe('source')
-      })
-
-      it('popover text', async () => {
-        const popover = await page.$eval(source_input_sel, e => e.getAttribute('popover'))
-        await expect(popover).toBe('Link to more information about profile')
-      })
-
-      it('validates with checkURL', async () => {
-        const ng_blur = await page.$eval(source_input_sel, e => e.getAttribute('ng-blur'))
-        await expect(ng_blur).toBe('checkURL()')
-      })
-
+  describe('Adding a Property Template', () => {
+    beforeEach(async () => {
+      await page.waitForSelector('.propertyLink')
+      await page.click('.propertyLink')
+      await expect(page).toMatch('Property Template')
     })
 
-    describe('Adding a Resource Template', () => {
+    it('now has 3 input fields for property ID once a resource template is added', async () => {
+      const inputs = await page.$eval('div[id="property_1"] > div > table', e => e.getElementsByTagName('input').length)
+      expect(inputs).toBe(3)
+      await page.waitFor(1000)
+      await expect(page).toMatch('Property URI')
+      await expect(page).toMatch('Type')
+      await expect(page).toMatch('Mandatory')
+      await expect(page).toMatch('Property Label')
+      await expect(page).toMatch('Repeatable')
+    })
+  })
 
-      beforeAll(async () => {
-          await page.waitForSelector('#addResource')
-          await page.click('#addResource')
-          await page.waitFor(1000)
-      })
-
-        it('displays a new resource template span', async () => {
-            const title = await page.$eval('span[id="0"] > span', e => e.getAttribute('popover-title'))
-            const span = await page.$eval('span[id="0"] > span', e => e.textContent)
-            expect(title).toMatch(/Resource ID: Undefined/)
-            expect(span).toMatch(/Resource Template/)
-        })
-
-        it('has eight input fields for the profile admin data', async () => {
-            const inputs = await page.$eval('div[id="profile"] > div > table', e => e.getElementsByTagName('input').length)
-            expect(inputs).toBe(8)
-            await expect(page).toMatch('ID')
-            await expect(page).toMatch('Description')
-            await expect(page).toMatch('Contact')
-            await expect(page).toMatch('Title')
-            await expect(page).toMatch('Date')
-            await expect(page).toMatch('Remark')
-            await expect(page).toMatch('Adherence')
-            await expect(page).toMatch('Source')
-        })
-
-        it('has five input fields for the resource template data', async () => {
-            const inputs = await page.$eval('div[id="resource_0"] > div > table', e => e.getElementsByTagName('input').length)
-            expect(inputs).toBe(5)
-            await expect(page).toMatch('ID')
-            await expect(page).toMatch('Resource Label')
-            await expect(page).toMatch('Guiding statement for the use of this resource')
-            await expect(page).toMatch('Resource URI')
-        })
+  describe('Removing the resource template', () => {
+    beforeEach(async () => {
+      await page.waitForSelector('#deleteButton')
+      await page.click('#deleteButton')
+      await page.waitForSelector('#deleteModal')
+      await page.waitFor(1000)
+      await page.click('#deleteModal > div > div > div.modal-body > button:nth-child(1)')
     })
 
-    describe('Adding a Property Template', () => {
-        beforeEach(async () => {
-            await page.waitForSelector('.propertyLink')
-            await page.click('.propertyLink')
-            await expect(page).toMatch('Property Template')
-        })
-
-        it('now has 3 input fields for property ID once a resource template is added', async () => {
-            const inputs = await page.$eval('div[id="property_1"] > div > table', e => e.getElementsByTagName('input').length)
-            expect(inputs).toBe(3)
-            await page.waitFor(1000)
-            await expect(page).toMatch('Property URI')
-            await expect(page).toMatch('Type')
-            await expect(page).toMatch('Mandatory')
-            await expect(page).toMatch('Property Label')
-            await expect(page).toMatch('Repeatable')
-        })
-    });
-
-    describe('Removing the resource template', () => {
-        beforeEach(async () => {
-            await page.waitForSelector('#deleteButton')
-            await page.click('#deleteButton')
-            await page.waitForSelector('#deleteModal')
-            await page.waitFor(1000)
-            await page.click('#deleteModal > div > div > div.modal-body > button:nth-child(1)')
-        })
-
-        it('now has no span or input fields for the resource template', async () => {
-            await expect(page).not.toMatch('Property Template')
-            await expect(page).not.toMatch('span', { text: 'Resource Template' })
-        })
-    });
-
-    describe('Profile fields errors', () => {
-
-      it('displays error if source and user switches focus', async () => {
-        await page
-          .type(source_input_sel, '')
-          .catch(error => console.log(`promise error for : ${error}`))
-        await page.keyboard.press(`Tab`)
-        await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-header > h3', 'Error!')
-        const invalid_url_class = page.$('input#resourceURI', e => e.getAttribute('ng-invalid-url'))
-        expect(invalid_url_class).toBeDefined()
+    it('now has no span or input fields for the resource template', async () => {
+      await expect(page).not.toMatch('Property Template')
+      await expect(page).not.toMatch('span', {
+        text: 'Resource Template'
       })
-
     })
+  })
 
-});
+  describe('Profile fields errors', () => {
+
+    it('displays error if source and user switches focus', async () => {
+      await page
+        .type(source_input_sel, '')
+        .catch(error => console.log(`promise error for : ${error}`))
+      await page.keyboard.press(`Tab`)
+      await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-header > h3', 'Error!')
+      const invalid_url_class = page.$('input#resourceURI', e => e.getAttribute('ng-invalid-url'))
+      expect(invalid_url_class).toBeDefined()
+    })
+  })
+
+})
 
 async function expect_value_in_selector_textContent(sel, value) {
   const sel_text = await page.$eval(sel, e => e.textContent)

--- a/source/html/propertyTemplate.html
+++ b/source/html/propertyTemplate.html
@@ -29,7 +29,7 @@
             <tbody>
                 <tr>
                     <td>
-                        <label for="propertyURI">Property URI</label>
+                        <label for="propertyURI">Property URI*</label>
                     </td>
                     <td>
                         <input type="url" name="propertyURI" ng-model="propertyTemplate.propertyURI" required
@@ -48,7 +48,7 @@
                         </div>
                     </td>
                     <td>
-                        <label for="propertyLabel">Property Label</label>
+                        <label for="propertyLabel">Property Label*</label>
                     </td>
                     <td>
                         <input name="propertyLabel" ng-model="propertyTemplate.propertyLabel"
@@ -59,7 +59,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="type">Type</label>
+                        <label for="type">Type*</label>
                     </td>
                     <td>
                         <select name="type" ng-model="propertyTemplate.type"

--- a/source/html/resourceTemplate.html
+++ b/source/html/resourceTemplate.html
@@ -27,7 +27,7 @@
             <tbody>
                 <tr>
                     <td>
-                        <label for="id">ID</label>
+                        <label for="id">ID*</label>
                     </td>
                     <td>
                         <input name="resourceId" ng-model="resourceTemplate.id" ng-change="checkID()" required
@@ -40,7 +40,7 @@
                     </td>
 
                     <td>
-                        <label for="resourceURI">Resource URI</label>
+                        <label for="resourceURI">Resource URI*</label>
                     </td>
                     <td>
                         <input  type="url" name="resourceURI" ng-model="resourceTemplate.resourceURI" required
@@ -62,31 +62,31 @@
 
                 <tr>
                     <td>
-                       <label for="resourceLabel">Resource Label</label>
+                       <label for="resourceLabel">Resource Label*</label>
                     </td>
                     <td>
                        <input name="resourceLabel" ng-model="resourceTemplate.resourceLabel"
-                              popover="Localized label associated with the resource"
+                              popover="Localized label associated with the resource template"
                               popover-title="Resource Label" popover-trigger="mouseenter"
                               popover-placement="right"/>
                     </td>
 
                     <td>
-                        <label for="author">Author</label>
+                        <label for="rtAuthor">Author*</label>
                     </td>
                     <td>
-                        <input name="author" ng-model="resourceTemplate.author"
-                               popover="Contact information associated with the profile"
+                        <input name="rtAuthor" ng-model="resourceTemplate.author"
+                               popover="Contact information associated with the resource template"
                                popover-title="Resource Title" popover-trigger="mouseenter"
                                popover-placement="left"/>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="remark">Guiding statement for the use of this resource</label>
+                        <label for="rtRemark">Guiding statement for the use of this resource</label>
                     </td>
                     <td>
-                        <input name="remark" ng-model="resourceTemplate.remark"
+                        <input name="rtRemark" ng-model="resourceTemplate.remark"
                                 popover="Comment or guiding statement intended to be presented as supplementary information in user display. A common use for this is to notify a user of code lists or schemata associated with the expected value of this resource."
                                 popover-title="Remark" popover-trigger="mouseenter"
                                 popover-placement="right"/>


### PR DESCRIPTION
- add asterisk to indicate required field to:
  - profile metadata:  (tests added)
  - resource template metadata: rt id, resourceURI, resourceLabel, author
  - property template:  propertyURI, propertyLabel, type
- some small refactoring of existing tests to improve readability (indenting was messed up on one)
- added tests that should have gone with #166

Fixes #190

### Before
![image](https://user-images.githubusercontent.com/96775/52753772-e6870700-2fac-11e9-98e6-6f408c904c17.png)

### After
![requiredfields](https://user-images.githubusercontent.com/96775/52753897-657c3f80-2fad-11e9-9e03-a9eba33f1e33.png)
