### PR TITLE
profiles, templates given schema version 0.0.9

### DIFF
--- a/source/__tests__/__fixtures__/foo_profile_sinopia_v0.0.9.json
+++ b/source/__tests__/__fixtures__/foo_profile_sinopia_v0.0.9.json
@@ -1,0 +1,43 @@
+{
+  "Profile": {
+    "resourceTemplates": [
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "lookup",
+            "valueConstraint": {
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/names",
+                "http://id.loc.gov/authorities/subjects"
+              ]
+            },
+            "propertyLabel": "Search LCNAF/LCSH",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "literal",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Record Foo (if it does not appear above)",
+            "remark": "http://access.rdatoolkit.org/6.5.html"
+          }
+        ],
+        "id": "sinopia:resourceTemplate:bf2:Foo",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Foo",
+        "resourceLabel": "Foo Associated with a Work",
+        "author": "NDMSO",
+        "date": "2017-05-13",
+        "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+      }
+    ],
+    "id": "sinopia:profile:bf2:Foo",
+    "title": "BIBFRAME 2.0 Foo",
+    "date": "2017-05-13",
+    "description": "Foo Associated with a Resource",
+    "author": "NDMSO",
+    "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json"
+  }
+}

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -144,6 +144,22 @@ describe('Importing a profile from a json file', () => {
 
 })
 
+it('imports an existing v0.0.9 profile and resource templates', async () => {
+  await page.goto('http://localhost:8000/#/profile/create/true')
+
+  const bf_item_location = path.join(__dirname, "..", "__fixtures__", 'foo_profile_sinopia_v0.0.9.json')
+  await expect(page).toUploadFile(
+    'input[type="file"]',
+    bf_item_location,
+  )
+  await page.waitForSelector('span[popover-title="Profile ID: sinopia:profile:bf2:Foo"]')
+    .then(async () => {
+      await expect_regex_in_sel_textContent('span[popover-title="Profile ID: sinopia:profile:bf2:Foo"]', 'BIBFRAME 2.0 Foo')
+      await expect_regex_in_sel_textContent('span[popover-title="Resource ID: sinopia:resourceTemplate:bf2:Foo"]', 'Foo Associated with a Work')
+    })
+    .catch(error => console.log(`promise error for import v0.0.9 profile: ${error}`))
+})
+
 it('imports an existing v0.1.0 profile and resource templates', async () => {
   await page.goto('http://localhost:8000/#/profile/create/true')
 

--- a/source/assets/js/modules/profile/services/formHandler.service.js
+++ b/source/assets/js/modules/profile/services/formHandler.service.js
@@ -26,9 +26,9 @@ angular.module('locApp.modules.profile.services')
         };
 
         var addSchemaUrls = function(profile) {
-          profile.schema = 'https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json'
+          profile.schema = 'https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json'
           angular.forEach(profile.resourceTemplates, function(resource){
-              resource.schema = 'https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json'
+              resource.schema = 'https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json'
           })
         }
 


### PR DESCRIPTION
Inserts v0.0.9 schema url in profiles and resource templates, instead of 0.1.0.   0.0.9 is more relaxed and what is output is much more likely to be schema valid.  

PE still can produce invalid schemas:  if type "resource" has no "valueTemplateRefs" or type "lookup" has no "useValuesFrom", or if labels are missing. 

Closes #200