### PR TITLE
tests hopefully pass more often

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
     {
       files: "**/*.js",
       env: {
-        jest: true
+        jest: true,
+        jquery: true
       },
       plugins: [ "jest", "security" ],
       rules: {
@@ -22,6 +23,7 @@ module.exports = {
       },
       "globals": {
           "angular": true,
+          "browser": true,
           "document": true,
           "page": true,
           "window": true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![CircleCI](https://circleci.com/gh/LD4P/sinopia_profile_editor.svg?style=svg)](https://circleci.com/gh/LD4P/sinopia_profile_editor)
 [![Coverage Status](https://coveralls.io/repos/github/LD4P/sinopia_profile_editor/badge.svg)](https://coveralls.io/github/LD4P/sinopia_profile_editor)
 
+NOTE:  tests fail intermittently, both on local environments and in circleci.
+The test failures are not the same each time - re-running tests locally and in circleci may be necessary to get a green build.
+
 # LD4P's BIBFRAME Profile Editor
 
 forked from https://github.com/lcnetdev/profile-edit
@@ -51,6 +54,9 @@ The javascript code uses grunt as a build tool. See `Gruntfile.js` for build dep
 
 Tests are written in jest, also utilizing puppeteer for end-to-end tests.  Be
 sure to run `npm install && grunt` before running the tests with `npm test`.
+
+NOTE:  tests fail intermittently, both on local environments and in circleci.
+The test failures are not the same each time - re-running tests locally and in circleci may be necessary to get a green build.
 
 #### test coverage
 To get coverage data, `npm run test-cov`.  Use a web browser to open `coverage/lcov-report/index.html`.  There is a project view and also a view of each file.  You can also check [coveralls](https://coveralls.io/repos/github/LD4P/sinopia_profile_editor)

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
     "reporters": [
       "default",
       "jest-junit"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      ".*/jestPuppeteerHelper.js"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "dev-test": "npm install && npm run grunt-dev && jest --colors",
-    "eslint": "eslint --color --max-warnings 170 -c .eslintrc.js .",
+    "eslint": "eslint --color --max-warnings 145 -c .eslintrc.js .",
     "grunt-dev": "grunt ngAnnotate uglify cssmin",
     "jest-ci": "jest --coverage --colors --silent --ci --runInBand --reporters=default --reporters=jest-junit && cat ./coverage/lcov.info | coveralls",
     "jest-cov": "jest --coverage --colors --silent",

--- a/source/__tests__/integration/create-ontologies.test.js
+++ b/source/__tests__/integration/create-ontologies.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Create profile has ontologies available for resource template', () => {
   const modalSel = 'div#chooseResource > div.modal-dialog > div.modal-content'
@@ -15,7 +16,7 @@ describe('Create profile has ontologies available for resource template', () => 
     expect.assertions(1)
 
     const modalTitleSel = `${modalSel} > div.modal-header > h3.modal-title`
-    await expect_value_in_sel_textContent(modalTitleSel, 'Choose Resource Template')
+    await pupExpect.expectSelTextContentToBe(modalTitleSel, 'Choose Resource Template')
   })
 
   describe('ontologies select', () => {
@@ -55,13 +56,7 @@ describe('Create profile has ontologies available for resource template', () => 
       await expect(page).toSelect(selectVocabSel, 'RDF')
 
       const resourcePickSel = `${modalBodySel} > select#resourcePick`
-      await expect_value_in_sel_textContent(`${resourcePickSel} > option:nth-child(1)`, 'Property')
+      await pupExpect.expectSelTextContentToBe(`${resourcePickSel} > option:nth-child(1)`, 'Property')
     })
   })
 })
-
-async function expect_value_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toBe(value)
-}

--- a/source/__tests__/integration/create-ontologies.test.js
+++ b/source/__tests__/integration/create-ontologies.test.js
@@ -63,5 +63,5 @@ describe('Create profile has ontologies available for resource template', () => 
 async function expect_value_in_sel_textContent(sel, value) {
   await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }

--- a/source/__tests__/integration/create-profile.test.js
+++ b/source/__tests__/integration/create-profile.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Validating the profile metadata', () => {
 
@@ -26,7 +27,7 @@ describe('Validating the profile metadata', () => {
           title: title
         })
         await expect(page).toClick('a', { text: 'Export'})
-        await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-body > p', 'Parts of the form are invalid')
+        await pupExpect.expectSelTextContentToBe('#alertBox > div > div > div.modal-body > p', 'Parts of the form are invalid')
         await page.reload({waitUntil: 'networkidle2'});
     })
   })
@@ -42,13 +43,7 @@ describe('Validating the profile metadata', () => {
       })
       await expect(page).toClick('a', { text: 'Export'})
       const alertMsg = 'Profile must have at least one resource template'
-      await expect_value_in_selector_textContent('#alertBox > div > div > div.modal-body > p', alertMsg)
+      await pupExpect.expectSelTextContentToBe('#alertBox > div > div > div.modal-body > p', alertMsg)
     })
   })
 })
-
-async function expect_value_in_selector_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toBe(value)
-}

--- a/source/__tests__/integration/create-profile.test.js
+++ b/source/__tests__/integration/create-profile.test.js
@@ -48,6 +48,7 @@ describe('Validating the profile metadata', () => {
 })
 
 async function expect_value_in_selector_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }

--- a/source/__tests__/integration/create-property.test.js
+++ b/source/__tests__/integration/create-property.test.js
@@ -174,6 +174,7 @@ describe('property URI and Label are required', () => {
       propertyLabel: 'propLabel'
     })
     // wait for resourceURI check
+    await page.waitFor(1000, {waitUntil: 'networkidle2'})
     const valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
     expect(valid_url_class).toBeTruthy()
 
@@ -215,11 +216,10 @@ describe('property URI and Label are required', () => {
       propertyURI: 'not-a-uri',
       propertyLabel: 'propLabel'
     })
-    // wait for resourceURI check
+    // wait for resourceURI and propertyURI checks
+    await page.waitFor(1000, {waitUntil: 'networkidle2'})
     const valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
     expect(valid_url_class).toBeTruthy()
-
-    // wait for propertyURI check
     const invalid_url_class = await page.$('input[name="propertyURI"]', e => e.getAttribute('ng-invalid-url'))
     expect(invalid_url_class).toBeTruthy()
 
@@ -240,15 +240,12 @@ describe('property URI and Label are required', () => {
       resourceURI: "http://www.example.com#after",
       propertyURI: "http://www.example.org#foo"
     })
-    // wait for resourceURI check
+    // wait for resourceURI and propertyURI checks
+    await page.waitFor(1000, {waitUntil: 'networkidle2'})
     let valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
     expect(valid_url_class).toBeTruthy()
-    await page.waitFor(1000, {waitUntil: 'networkidle2'})
-
-    // wait for propertyURI check
     valid_url_class = await page.$('input[name="propertyURI"]', e => e.getAttribute('ng-valid-url'))
     expect(valid_url_class).toBeTruthy()
-    await page.waitFor(1000, {waitUntil: 'networkidle2'})
 
     await page.click(exportButtonSel)
     await page.waitForSelector('a[download="My Profile.json"]')
@@ -276,14 +273,17 @@ describe('choose propertyTemplate from menu', () => {
 })
 
 async function expect_sel_to_exist(sel) {
+  await page.waitForSelector(sel)
   const sel_text = !!(await page.$(sel))
-  expect(sel_text).toEqual(true)
+  return expect(sel_text).toEqual(true)
 }
 async function expect_value_in_sel_text(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text.trim()).toBe(value)
+  return expect(sel_text.trim()).toBe(value)
 }
 async function expect_value_not_in_sel_text(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text.trim()).not.toBe(value)
+  return expect(sel_text.trim()).not.toBe(value)
 }

--- a/source/__tests__/integration/create-property.test.js
+++ b/source/__tests__/integration/create-property.test.js
@@ -24,7 +24,7 @@ describe('PropertyTemplate requirements', () => {
 
     it('clicking "Add Property Template" appends a property template section to the form', async () => {
       expect.assertions(1)
-      page.waitForSelector(ptFieldsTableSel)
+      await page.waitForSelector(ptFieldsTableSel)
       await pupExpect.expectSelToExist('i.fa-exclamation[id="error"]')
     })
 

--- a/source/__tests__/integration/create-property.test.js
+++ b/source/__tests__/integration/create-property.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('PropertyTemplate requirements', () => {
   beforeAll(async () => {
@@ -24,7 +25,7 @@ describe('PropertyTemplate requirements', () => {
     it('clicking "Add Property Template" appends a property template section to the form', async () => {
       expect.assertions(1)
       page.waitForSelector(ptFieldsTableSel)
-      await expect_sel_to_exist('i.fa-exclamation[id="error"]')
+      await pupExpect.expectSelToExist('i.fa-exclamation[id="error"]')
     })
 
     describe('property template form fields', () => {
@@ -42,33 +43,33 @@ describe('PropertyTemplate requirements', () => {
       describe('Required fields are indicated with asterisk', () => {
         it('Property URI', async () => {
           expect.assertions(1)
-          await expect_value_in_sel_text(`${ptFieldsTableSel} label[for="propertyURI"]`, "Property URI*")
+          await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="propertyURI"]`, "Property URI*")
         })
         it('Property Label', async () => {
           expect.assertions(1)
-          await expect_value_in_sel_text(`${ptFieldsTableSel} label[for="propertyLabel"]`, "Property Label*")
+          await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="propertyLabel"]`, "Property Label*")
         })
         it('Type', async () => {
           expect.assertions(1)
-          await expect_value_in_sel_text(`${ptFieldsTableSel} label[for="type"]`, "Type*")
+          await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="type"]`, "Type*")
         })
       })
 
       describe('Non-required fields have no asterisk', () => {
         it('Remark', async () => {
           expect.assertions(2)
-          await expect_value_not_in_sel_text(`${ptFieldsTableSel} label[for="remark"]`, "Guiding statement for the use of this property*")
-          await expect_value_in_sel_text(`${ptFieldsTableSel} label[for="remark"]`, "Guiding statement for the use of this property")
+          await pupExpect.expectSelTextContentNotToBe(`${ptFieldsTableSel} label[for="remark"]`, "Guiding statement for the use of this property*")
+          await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="remark"]`, "Guiding statement for the use of this property")
         })
         it('Mandatory', async () => {
           expect.assertions(2)
-          await expect_value_not_in_sel_text(`${ptFieldsTableSel} label[for="mandatory"]`, "Mandatory*")
-          await expect_value_in_sel_text(`${ptFieldsTableSel} label[for="mandatory"]`, "Mandatory")
+          await pupExpect.expectSelTextContentNotToBe(`${ptFieldsTableSel} label[for="mandatory"]`, "Mandatory*")
+          await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="mandatory"]`, "Mandatory")
         })
         it('Repeatable', async () => {
           expect.assertions(2)
-          await expect_value_not_in_sel_text(`${ptFieldsTableSel} label[for="repeatable"]`, "Repeatable*")
-          await expect_value_in_sel_text(`${ptFieldsTableSel} label[for="repeatable"]`, "Repeatable")
+          await pupExpect.expectSelTextContentNotToBe(`${ptFieldsTableSel} label[for="repeatable"]`, "Repeatable*")
+          await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="repeatable"]`, "Repeatable")
         })
       })
     })
@@ -79,7 +80,7 @@ describe('PropertyTemplate requirements', () => {
       describe('Value Constraint', () => {
         it('header', async () => {
           expect.assertions(1)
-          await expect_value_in_sel_text(`${vcFieldsTableSel} > #constraintHeader`, "Value Constraint")
+          await pupExpect.expectSelTextContentToBe(`${vcFieldsTableSel} > #constraintHeader`, "Value Constraint")
         })
         it('has no input fields', async () => {
           expect.assertions(1)
@@ -93,7 +94,7 @@ describe('PropertyTemplate requirements', () => {
         })
         it('has Add Default Link', async () => {
           expect.assertions(1)
-          await expect_value_in_sel_text(`${vcFieldsTableSel} > a#addDefault`, "Add Default")
+          await pupExpect.expectSelTextContentTrimmedToMatch(`${vcFieldsTableSel} > a#addDefault`, "Add Default")
         })
       })
 
@@ -111,7 +112,7 @@ describe('PropertyTemplate requirements', () => {
         })
         it('has URI field', async () => {
           expect.assertions(1)
-          await expect_value_in_sel_text(`${vdtTableSel} label[for="dataTypeURI"]`, "URI")
+          await pupExpect.expectSelTextContentToBe(`${vdtTableSel} label[for="dataTypeURI"]`, "URI")
         })
       })
 
@@ -128,17 +129,17 @@ describe('PropertyTemplate requirements', () => {
           // NOTE: the html always shows the first option selected, though the browser
           //  shows the right thing.  So here we cheat and use indirect checking of attributes
           //  to show a template can be selected
-          await expect_sel_to_exist(`${propTemplateSelectSelector}.ng-pristine`)
-          await expect_sel_to_exist(`${propTemplateSelectSelector} > option[selected="selected"][value="?"]`)
+          await pupExpect.expectSelToExist(`${propTemplateSelectSelector}.ng-pristine`)
+          await pupExpect.expectSelToExist(`${propTemplateSelectSelector} > option[selected="selected"][value="?"]`)
           await page.select(propTemplateSelectSelector, 'sinopia:resourceTemplate:bf2:Form')
-          await expect_sel_to_exist(`${propTemplateSelectSelector}.ng-dirty`)
-          await expect_sel_to_exist(`${propTemplateSelectSelector} > option[selected="selected"][value^="sinopia:resourceTemplate:bf2"]`)
+          await pupExpect.expectSelToExist(`${propTemplateSelectSelector}.ng-dirty`)
+          await pupExpect.expectSelToExist(`${propTemplateSelectSelector} > option[selected="selected"][value^="sinopia:resourceTemplate:bf2"]`)
         })
       })
 
       it('Values - has Add Value link', async () => {
         expect.assertions(1)
-        await expect_value_in_sel_text(`${vcFieldsTableSel} > div#value > a#adValue`, "Add Value")
+        await pupExpect.expectSelTextContentTrimmedToMatch(`${vcFieldsTableSel} > div#value > a#adValue`, "Add Value")
       })
     })
   })
@@ -146,7 +147,7 @@ describe('PropertyTemplate requirements', () => {
   describe('property header appearence', () => {
     it('font-awesome icon class is present', async () => {
       expect.assertions(1)
-      await expect_sel_to_exist(`.fa-caret-right`)
+      await pupExpect.expectSelToExist(`.fa-caret-right`)
     })
   })
 })
@@ -179,7 +180,7 @@ describe('property URI and Label are required', () => {
     expect(valid_url_class).toBeTruthy()
 
     await page.click(exportButtonSel)
-    await expect_value_in_sel_text(alertBoxSel, 'Parts of the form are invalid')
+    await pupExpect.expectSelTextContentToBe(alertBoxSel, 'Parts of the form are invalid')
   })
 
   it('error if exported without property Label', async () => {
@@ -200,7 +201,7 @@ describe('property URI and Label are required', () => {
     expect(valid_url_class).toBeTruthy()
 
     await page.click(exportButtonSel)
-    await expect_value_in_sel_text(alertBoxSel, 'Parts of the form are invalid')
+    await pupExpect.expectSelTextContentToBe(alertBoxSel, 'Parts of the form are invalid')
   })
 
   it('error if exported with invalid property uri', async () => {
@@ -225,7 +226,7 @@ describe('property URI and Label are required', () => {
 
     await page.click(exportButtonSel)
     await page.waitForSelector(alertBoxSel)
-    await expect_value_in_sel_text(alertBoxSel, "Parts of the form are invalid")
+    await pupExpect.expectSelTextContentToBe(alertBoxSel, "Parts of the form are invalid")
   })
 
   it('can be exported with valid property URI', async () => {
@@ -268,22 +269,6 @@ describe('choose propertyTemplate from menu', () => {
     await page.waitForSelector('select[name="chooseVocab"]')
     await expect(page).toSelect('select[name="chooseVocab"]', 'Bibframe 2.0')
     await expect(page).toSelect('#resourcePick', 'Absorbed by')
-    await expect_value_in_sel_text('div.propertyItem span[href="#property_1"] > span', 'Absorbed by')
+    await pupExpect.expectSelTextContentTrimmedToMatch('div.propertyItem span[href="#property_1"] > span', 'Absorbed by')
   })
 })
-
-async function expect_sel_to_exist(sel) {
-  await page.waitForSelector(sel)
-  const sel_text = !!(await page.$(sel))
-  return expect(sel_text).toEqual(true)
-}
-async function expect_value_in_sel_text(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text.trim()).toBe(value)
-}
-async function expect_value_not_in_sel_text(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text.trim()).not.toBe(value)
-}

--- a/source/__tests__/integration/create-resource.test.js
+++ b/source/__tests__/integration/create-resource.test.js
@@ -68,6 +68,7 @@ describe('Create profile resource template requirements', () => {
         resourceURI: "http://www.stanford.edu"
       })
       // wait for resourceURI check
+      await page.waitFor(1000, {waitUntil: 'networkidle2'})
       const valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
       expect(valid_url_class).toBeTruthy()
 
@@ -104,10 +105,10 @@ describe('Create profile resource template requirements', () => {
           propertyURI: 'http://www.example.org',
           propertyLabel: 'propLabel'
         })
-        // wait for resourceURI check
+        // wait for resourceURI and propertyURI checks
+        await page.waitFor(1000, {waitUntil: 'networkidle2'})
         let valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
         expect(valid_url_class).toBeTruthy()
-        // wait for propertyURI check
         valid_url_class = await page.$('input[name="propertyURI"]', e => e.getAttribute('ng-valid-url'))
         expect(valid_url_class).toBeTruthy()
 
@@ -130,6 +131,7 @@ describe('Create profile resource template requirements', () => {
           propertyLabel: 'propLabel'
         })
         // wait for propertyURI check
+        await page.waitFor(1000, {waitUntil: 'networkidle2'})
         const valid_url_class = await page.$('input[name="propertyURI"]', e => e.getAttribute('ng-valid-url'))
         expect(valid_url_class).toBeTruthy()
 
@@ -154,15 +156,15 @@ describe('Create profile resource template requirements', () => {
           propertyURI: 'http://www.example.org',
           propertyLabel: 'propLabel'
         })
-        // wait for resourceURI check
+        // wait for resourceURI and propertyURI checks
+        await page.waitFor(1000, {waitUntil: 'networkidle2'})
         let valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
         expect(valid_url_class).toBeTruthy()
-        // wait for propertyURI check
         valid_url_class = await page.$('input[name="propertyURI"]', e => e.getAttribute('ng-valid-url'))
         expect(valid_url_class).toBeTruthy()
 
         await page.click(exportButtonSel)
-        await page.waitForSelector('a[download="My profile.json"]')
+        await page.waitForSelector('a[download="My profile.json"]', {visible: true})
         const data = await page.$eval('a[download="My profile.json"]', e => e.getAttribute('href'))
         const json = JSON.parse(decodeURIComponent(data.substr(data.indexOf(',') + 1)))
         expect(json['Profile']['id']).toBe('my:profile')
@@ -173,14 +175,17 @@ describe('Create profile resource template requirements', () => {
 })
 
 async function expect_regex_in_sel_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toMatch(value)
+  return expect(sel_text).toMatch(value)
 }
 async function expect_value_in_sel_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }
 async function expect_value_not_in_sel_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text.trim()).not.toBe(value)
+  return expect(sel_text.trim()).not.toBe(value)
 }

--- a/source/__tests__/integration/create-resource.test.js
+++ b/source/__tests__/integration/create-resource.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Create profile resource template requirements', () => {
 
@@ -15,7 +16,7 @@ describe('Create profile resource template requirements', () => {
     it('appends a resource template section to the form', async () => {
       expect.assertions(1)
       await page.waitForSelector('span[id="0"] > span')
-      await expect_regex_in_sel_textContent('span[id="0"] > span', /^Resource Template\s*$/)
+      await pupExpect.expectSelTextContentToMatch('span[id="0"] > span', /^Resource Template\s*$/)
     })
 
     it('has five input fields for the resource template data', async () => {
@@ -27,27 +28,27 @@ describe('Create profile resource template requirements', () => {
     describe('Required fields are indicated with asterisk', () => {
       it('ID', async () => {
         expect.assertions(1)
-        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="id"]`, "ID*")
+        await pupExpect.expectSelTextContentToBe(`${rt_fields_table_sel} label[for="id"]`, "ID*")
       })
       it('Resource URI', async () => {
         expect.assertions(1)
-        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="resourceURI"]`, "Resource URI*")
+        await pupExpect.expectSelTextContentToBe(`${rt_fields_table_sel} label[for="resourceURI"]`, "Resource URI*")
       })
       it('Resource Label', async () => {
         expect.assertions(1)
-        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="resourceLabel"]`, "Resource Label*")
+        await pupExpect.expectSelTextContentToBe(`${rt_fields_table_sel} label[for="resourceLabel"]`, "Resource Label*")
       })
       it('Author', async () => {
         expect.assertions(1)
-        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="rtAuthor"]`, "Author*")
+        await pupExpect.expectSelTextContentToBe(`${rt_fields_table_sel} label[for="rtAuthor"]`, "Author*")
       })
     })
 
     describe('Non-required fields have no asterisk', () => {
       it('Remark', async () => {
         expect.assertions(2)
-        await expect_value_not_in_sel_textContent(`${rt_fields_table_sel} label[for="rtRemark"]`, "Guiding statement for the use of this resource*")
-        await expect_value_in_sel_textContent(`${rt_fields_table_sel} label[for="rtRemark"]`, "Guiding statement for the use of this resource")
+        await pupExpect.expectSelTextContentNotToBe(`${rt_fields_table_sel} label[for="rtRemark"]`, "Guiding statement for the use of this resource*")
+        await pupExpect.expectSelTextContentToBe(`${rt_fields_table_sel} label[for="rtRemark"]`, "Guiding statement for the use of this resource")
       })
     })
   })
@@ -74,7 +75,7 @@ describe('Create profile resource template requirements', () => {
 
       await page.click(exportButtonSel)
       await page.waitForSelector(alertBoxSel)
-      await expect_value_in_sel_textContent(alertBoxSel, "my:resource must have at least one property template")
+      await pupExpect.expectSelTextContentToBe(alertBoxSel, "my:resource must have at least one property template")
     })
 
     describe('with property template', () => {
@@ -114,7 +115,7 @@ describe('Create profile resource template requirements', () => {
 
         await page.click(exportButtonSel)
         await page.waitForSelector(alertBoxSel)
-        await expect_value_in_sel_textContent(alertBoxSel, "Parts of the form are invalid")
+        await pupExpect.expectSelTextContentToBe(alertBoxSel, "Parts of the form are invalid")
       })
 
       it('requires Resource URI', async () => {
@@ -140,7 +141,7 @@ describe('Create profile resource template requirements', () => {
 
         await page.click(exportButtonSel)
         await page.waitForSelector(alertBoxSel)
-        await expect_value_in_sel_textContent(alertBoxSel, "Parts of the form are invalid")
+        await pupExpect.expectSelTextContentToBe(alertBoxSel, "Parts of the form are invalid")
       })
 
       it('no alerts when all requirements are met', async () => {
@@ -173,19 +174,3 @@ describe('Create profile resource template requirements', () => {
     })
   })
 })
-
-async function expect_regex_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toMatch(value)
-}
-async function expect_value_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toBe(value)
-}
-async function expect_value_not_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text.trim()).not.toBe(value)
-}

--- a/source/__tests__/integration/export-profile.test.js
+++ b/source/__tests__/integration/export-profile.test.js
@@ -9,6 +9,7 @@ describe('Profiles Export', () => {
 
     // import a profile
     await page.goto('http://localhost:8000/#/profile/create/true')
+    await page.waitForSelector('input[type="file"]', {visible: true})
     const profilePath = path.join(__dirname, "..", "__fixtures__", 'item_profile_lc_v0.0.2.json')
     await expect(page).toUploadFile('input[type="file"]', profilePath)
     await page.waitForSelector('span[popover-title="Profile ID: profile:bf2:Item"]', {visible: true})
@@ -34,7 +35,7 @@ describe('Profiles Export', () => {
 
   describe('exports cleanly', () => {
     beforeAll(async () => {
-      await page.goto('http://127.0.0.1:8000/#/profile/create/')
+      return await page.goto('http://127.0.0.1:8000/#/profile/create/')
     })
 
     beforeEach(async () => {
@@ -59,7 +60,6 @@ describe('Profiles Export', () => {
       await page.waitFor(1000, {waitUntil: 'networkidle2'})
       const valid_url_class = await page.$('input[name="resourceURI"]', e => e.getAttribute('ng-valid-url'))
       expect(valid_url_class).toBeTruthy()
-      return new Promise(resolve => resolve())
     })
 
     afterEach(async() => {

--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -44,7 +44,6 @@ describe('Sinopia Profile Editor Homepage', () => {
     expect.assertions(2)
     const sel = 'a.btn.import-export[ng-click="showImport()"]'
     await expect(page).toClick(sel)
-    await page.waitFor(500) // shameless green: it needs more time here; not sure what to wait for
     const new_url = await page.evaluate(() => window.location.href)
     expect(new_url).toBe('http://127.0.0.1:8000/#/profile/create/true')
   })
@@ -63,14 +62,17 @@ describe('Sinopia Profile Editor Homepage', () => {
 })
 
 async function expect_sel_to_exist(sel) {
+  await page.waitForSelector(sel)
   const sel_text = !!(await page.$(sel))
-  expect(sel_text).toEqual(true)
+  return expect(sel_text).toEqual(true)
 }
 async function expect_regex_in_selector_textContent(sel, regex) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toMatch(regex)
+  return expect(sel_text).toMatch(regex)
 }
 async function expect_value_in_selector_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }

--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -9,9 +9,10 @@ describe('Sinopia Profile Editor Homepage', () => {
 
   it('redirects to profile/sinopia', async () => {
     expect.assertions(1)
-    await page.waitFor(500) // shameless green: not sure what to wait for
-    const new_url = await page.evaluate(() => window.location.href)
-    expect(new_url).toBe('http://127.0.0.1:8000/#/profile/sinopia')
+    const expectedUrl = 'http://127.0.0.1:8000/#/profile/sinopia'
+    await browser.waitForTarget(target => target.url() === expectedUrl)
+    const receivedUrl = await page.evaluate(() => window.location.href)
+    expect(receivedUrl).toBe(expectedUrl)
   })
 
   it('website title', async () => {
@@ -46,8 +47,8 @@ describe('Sinopia Profile Editor Homepage', () => {
     expect.assertions(2)
     const sel = 'a.btn.import-export[ng-click="showImport()"]'
     await expect(page).toClick(sel)
-    const new_url = await page.evaluate(() => window.location.href)
-    expect(new_url).toBe('http://127.0.0.1:8000/#/profile/create/true')
+    const receivedUrl = await page.evaluate(() => window.location.href)
+    expect(receivedUrl).toBe('http://127.0.0.1:8000/#/profile/create/true')
   })
 
   it('footer', async () => {

--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Sinopia Profile Editor Homepage', () => {
 
@@ -8,36 +9,37 @@ describe('Sinopia Profile Editor Homepage', () => {
 
   it('redirects to profile/sinopia', async () => {
     expect.assertions(1)
+    await page.waitFor(500) // shameless green: not sure what to wait for
     const new_url = await page.evaluate(() => window.location.href)
     expect(new_url).toBe('http://127.0.0.1:8000/#/profile/sinopia')
   })
 
   it('website title', async () => {
     expect.assertions(1)
-    await expect_value_in_selector_textContent('title', 'Sinopia Profile Editor')
+    await pupExpect.expectSelTextContentToBe('title', 'Sinopia Profile Editor')
   })
 
   describe('header', () => {
     it('title', async() => {
       expect.assertions(2)
-      await expect_value_in_selector_textContent('h2.sinopia-subtitle > a:nth-child(1)', 'Sinopia')
-      await expect_value_in_selector_textContent('h1.sinopia-title', 'Profile Editor')
+      await pupExpect.expectSelTextContentToBe('h2.sinopia-subtitle > a:nth-child(1)', 'Sinopia')
+      await pupExpect.expectSelTextContentToBe('h1.sinopia-title', 'Profile Editor')
     });
     it('links', async () => {
       expect.assertions(2)
-      await expect_value_in_selector_textContent('div.sinopia-headerlinks > a:nth-child(1)', 'Linked Data Editor')
-      await expect_value_in_selector_textContent('div.sinopia-headerlinks > a:nth-child(2)', 'Help and Resources')
+      await pupExpect.expectSelTextContentToBe('div.sinopia-headerlinks > a:nth-child(1)', 'Linked Data Editor')
+      await pupExpect.expectSelTextContentToBe('div.sinopia-headerlinks > a:nth-child(2)', 'Help and Resources')
     })
   })
 
   it('text on page', async () => {
     expect.assertions(1)
-    await expect_regex_in_selector_textContent('h3.new-profile-header', /\s*Create a new Profile or Import one from your files\s*$/)
+    await pupExpect.expectSelTextContentToMatch('h3.new-profile-header', /\s*Create a new Profile or Import one from your files\s*$/)
   })
 
   it('link to create new profile page', async () => {
     expect.assertions(1)
-    await expect_regex_in_selector_textContent('a.new-profile[href="#/profile/create/"]', /\s*Create new Profile\s*/)
+    await pupExpect.expectSelTextContentToMatch('a.new-profile[href="#/profile/create/"]', /\s*Create new Profile\s*/)
   })
 
   it('Import button redirects to profile/create/true', async () => {
@@ -51,28 +53,12 @@ describe('Sinopia Profile Editor Homepage', () => {
   it('footer', async () => {
     expect.assertions(3)
     await expect(page).toMatch('funded by the Andrew W. Mellon Foundation')
-    await expect_value_in_selector_textContent('div.sinopia-footer > a:nth-child(2)', 'Linked Data for Production 2 (LD4P2)')
-    await expect_value_in_selector_textContent('div.sinopia-footer > a:nth-child(3)', 'Creative Commons CC0 1.0 Universal Public Domain Dedication')
+    await pupExpect.expectSelTextContentToBe('div.sinopia-footer > a:nth-child(2)', 'Linked Data for Production 2 (LD4P2)')
+    await pupExpect.expectSelTextContentToBe('div.sinopia-footer > a:nth-child(3)', 'Creative Commons CC0 1.0 Universal Public Domain Dedication')
   })
 
   it('loads our angular app', async () => {
     expect.assertions(1)
-    await expect_sel_to_exist('html[ng-app="locApp"]')
+    await pupExpect.expectSelToExist('html[ng-app="locApp"]')
   })
 })
-
-async function expect_sel_to_exist(sel) {
-  await page.waitForSelector(sel)
-  const sel_text = !!(await page.$(sel))
-  return expect(sel_text).toEqual(true)
-}
-async function expect_regex_in_selector_textContent(sel, regex) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toMatch(regex)
-}
-async function expect_value_in_selector_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toBe(value)
-}

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -112,7 +112,6 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
       await page.waitForSelector(addValSel, {visible: true})
       await page.click(addValSel)
       const useValuesFromSel = 'div#value select[popover-title="Use Values From"]'
-      await page.waitFor(500) // shameless green: it needs more time here, can't tell why
       await page.waitForSelector(useValuesFromSel, {visible: true})
       await expect_regex_in_sel_textContent(useValuesFromSel, '')
       await expect_sel_to_exist(`${useValuesFromSel} > option[selected="selected"][value="?"]`)
@@ -142,7 +141,7 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
     expect.assertions(5)
     const resourceTemplateSpan = 'span[popover-title="Resource ID: profile:bf2:Item"]'
     await page.waitFor(500) // shameless green: it needs more time here, can't tell why
-    await page.waitFor(resourceTemplateSpan, {visible: true})
+    await page.waitForSelector(resourceTemplateSpan, {visible: true})
     await expect(page).toClick(resourceTemplateSpan)
     await page.waitForSelector('#resource_0 a.propertyLink')
 
@@ -205,20 +204,19 @@ it('imports propertyURI value with # char cleanly', async () => {
 async function expect_regex_in_sel_textContent(sel, value) {
   await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toMatch(value)
+  return expect(sel_text).toMatch(value)
 }
 async function expect_regex_not_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).not.toMatch(value)
+  return expect(sel_text).not.toMatch(value)
 }
 async function expect_value_in_sel_input(sel, value) {
   await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.value)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }
 async function expect_sel_to_exist(sel) {
   await page.waitForSelector(sel)
   const sel_text = !!(await page.$(sel))
-  expect(sel_text).toEqual(true)
+  return expect(sel_text).toEqual(true)
 }

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -1,5 +1,6 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 const path = require('path')
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('imports and edits a v0.0.2 profile from a json file', () => {
 
@@ -14,38 +15,38 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
 
   it('has expected profile attribute values and resource templates', async () => {
     expect.assertions(10) // includes 2 in beforeAll
-    await expect_regex_in_sel_textContent('span[popover-title="Profile ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Access"]', 'Lending or Access Policy')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Use"]', 'Use or Reproduction Policy')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Retention"]', 'Retention Policy')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:ImmAcqSource"]', 'Immediate Source of Acquisition')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Enumeration"]', 'Enumeration')
-    await expect_regex_in_sel_textContent('span[popover-title="Resource ID: profile:bf2:Item:Chronology"]', 'Chronology')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Profile ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item"]', 'BIBFRAME 2.0 Item')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item:Access"]', 'Lending or Access Policy')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item:Use"]', 'Use or Reproduction Policy')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item:Retention"]', 'Retention Policy')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item:ImmAcqSource"]', 'Immediate Source of Acquisition')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item:Enumeration"]', 'Enumeration')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: profile:bf2:Item:Chronology"]', 'Chronology')
   })
 
   it('has expected resource template with expected attribute values and property sections', async() => {
     expect.assertions(7)
     await expect(page).toClick('span[popover-title="Resource ID: profile:bf2:Item"]')
     await page.waitForSelector('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/sublocation"]', {visible: true})
-    await expect_value_in_sel_input('input[popover-title="Resource ID"]', 'profile:bf2:Item')
-    await expect_value_in_sel_input('input[popover-title="Resource URI"]', 'http://id.loc.gov/ontologies/bibframe/Item')
-    await expect_value_in_sel_input('input[popover-title="Resource Label"]', 'BIBFRAME 2.0 Item')
-    await expect_regex_in_sel_textContent('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/identifiedBy"]', 'Barcode')
-    await expect_regex_in_sel_textContent('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/sublocation"]', 'Shelving location')
-    await expect_regex_in_sel_textContent('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/acquisitionSource"]', 'Contact information (RDA 4.3)')
+    await pupExpect.expectSelValueToBe('input[popover-title="Resource ID"]', 'profile:bf2:Item')
+    await pupExpect.expectSelValueToBe('input[popover-title="Resource URI"]', 'http://id.loc.gov/ontologies/bibframe/Item')
+    await pupExpect.expectSelValueToBe('input[popover-title="Resource Label"]', 'BIBFRAME 2.0 Item')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/identifiedBy"]', 'Barcode')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/sublocation"]', 'Shelving location')
+    await pupExpect.expectSelTextContentToMatch('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/acquisitionSource"]', 'Contact information (RDA 4.3)')
   })
 
   it('has expected property with expected attribute values', async() => {
     expect.assertions(6)
     await expect(page).toClick('span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/identifiedBy"]')
     await page.waitForSelector('select[popover-title="Mandatory"]', {visible: true})
-    await expect_value_in_sel_input('input[popover-title="Property URI"]', 'http://id.loc.gov/ontologies/bibframe/identifiedBy')
-    await expect_value_in_sel_input('input[popover-title="Property Label"]', 'Barcode')
-    await expect_value_in_sel_input('select[popover-title="Mandatory"]', '0')
-    await expect_value_in_sel_input('select[popover-title="Repeatable"]', '1')
+    await pupExpect.expectSelValueToBe('input[popover-title="Property URI"]', 'http://id.loc.gov/ontologies/bibframe/identifiedBy')
+    await pupExpect.expectSelValueToBe('input[popover-title="Property Label"]', 'Barcode')
+    await pupExpect.expectSelValueToBe('select[popover-title="Mandatory"]', '0')
+    await pupExpect.expectSelValueToBe('select[popover-title="Repeatable"]', '1')
     const template_select_sel = 'div#template > div[item="0"] select[popover-title="Value Template Reference"]'
-    await expect_sel_to_exist(template_select_sel)
+    await pupExpect.expectSelToExist(template_select_sel)
   })
 
   describe('property template fields', () => {
@@ -67,8 +68,8 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
       await expect(page).toFill(defaultLiteralSel, 'my default literal')
 
       // NOTE: this is a shameless green way to hopefully show that data has been entered into the default form fields
-      await expect_sel_to_exist(`${defaultURIsel}.ng-dirty`)
-      await expect_sel_to_exist(`${defaultLiteralSel}.ng-dirty`)
+      await pupExpect.expectSelToExist(`${defaultURIsel}.ng-dirty`)
+      await pupExpect.expectSelToExist(`${defaultLiteralSel}.ng-dirty`)
     })
 
     //TODO: test selecting a Value Data type modal view and value selection
@@ -85,8 +86,8 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
 
       const resTemplateRefSel = `${lastResTempPropTempSel} #valueConstraints div#template select[popover-title="Value Template Reference"]`
       await page.waitForSelector(resTemplateRefSel)
-      await expect_regex_in_sel_textContent(resTemplateRefSel, '')
-      await expect_sel_to_exist(`${resTemplateRefSel} > option[selected="selected"][value="?"]`)
+      await pupExpect.expectSelTextContentToMatch(resTemplateRefSel, '')
+      await pupExpect.expectSelToExist(`${resTemplateRefSel} > option[selected="selected"][value="?"]`)
 
       // FIXME:  the selector should be populated with ids of resource templates from the server.  See #212
       const resTemplateId = 'profile:bf2:35mmFeatureFilm:Color'
@@ -97,13 +98,13 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
       await page.select(resTemplateRefSel, resTemplateId)
 
       // NOTE: could not get any of these to work
-      // await expect_sel_to_exist(`${resTemplateRefSel} > option[selected="selected"][value="${resTemplateId}"]`)
-      // await expect_sel_to_exist(`${resTemplateRefSel} > option[selected="selected"][value*="Color"]`)
-      // await expect_sel_to_exist(`${resTemplateRefSel} > option[selected="selected"][value^="profile:bf2"]`)
-      // await expect_regex_in_sel_textContent(resourceTemplateRefSel, "profile:bf2:35mmFeatureFilm:Color")
+      // await pupExpect.expectSelToExist(`${resTemplateRefSel} > option[selected="selected"][value="${resTemplateId}"]`)
+      // await pupExpect.expectSelToExist(`${resTemplateRefSel} > option[selected="selected"][value*="Color"]`)
+      // await pupExpect.expectSelToExist(`${resTemplateRefSel} > option[selected="selected"][value^="profile:bf2"]`)
+      // await pupExpect.expectSelTextContentToMatch(resourceTemplateRefSel, "profile:bf2:35mmFeatureFilm:Color")
 
       // NOTE: this is a shameless green way to hopefully show that a value has been selected
-      await expect_sel_to_exist(`${resTemplateRefSel}.ng-dirty`)
+      await pupExpect.expectSelToExist(`${resTemplateRefSel}.ng-dirty`)
     })
 
     it('"Values" Add Value allows URI selection', async() => {
@@ -113,12 +114,12 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
       await page.click(addValSel)
       const useValuesFromSel = 'div#value select[popover-title="Use Values From"]'
       await page.waitForSelector(useValuesFromSel, {visible: true})
-      await expect_regex_in_sel_textContent(useValuesFromSel, '')
-      await expect_sel_to_exist(`${useValuesFromSel} > option[selected="selected"][value="?"]`)
+      await pupExpect.expectSelTextContentToMatch(useValuesFromSel, '')
+      await pupExpect.expectSelToExist(`${useValuesFromSel} > option[selected="selected"][value="?"]`)
 
       await expect(page).toSelect(useValuesFromSel, 'AGROVOC (QA)')
-      await expect_sel_to_exist(`${useValuesFromSel} > option[selected="selected"][value="0"]`)
-      await expect_regex_in_sel_textContent(useValuesFromSel, 'AGROVOC (QA)')
+      await pupExpect.expectSelToExist(`${useValuesFromSel} > option[selected="selected"][value="0"]`)
+      await pupExpect.expectSelTextContentToMatch(useValuesFromSel, 'AGROVOC (QA)')
     })
   })
 
@@ -134,7 +135,7 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
 
     const resourcePickSel = `${modalBodySel} > select#resourcePick`
     await expect(page).toSelect(resourcePickSel, 'Role')
-    await expect_regex_in_sel_textContent('span[popover="URI: http://id.loc.gov/ontologies/bibframe/Role"]', 'Role')
+    await pupExpect.expectSelTextContentToMatch('span[popover="URI: http://id.loc.gov/ontologies/bibframe/Role"]', 'Role')
   })
 
   it('delete a property from a resource template', async() => {
@@ -147,14 +148,14 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
 
     const propTemplatesSel = '#resourceTemplates_0 > div[name="resourceForm"] div.panel-body div.propertyTemplates'
     const deleteTargetSel = `${propTemplatesSel} span[popover-title="Property URI: http://id.loc.gov/ontologies/bibframe/identifiedBy"]`
-    await expect_regex_in_sel_textContent(deleteTargetSel, 'Barcode')
+    await pupExpect.expectSelTextContentToMatch(deleteTargetSel, 'Barcode')
 
     await expect(page).toClick(`${propTemplatesSel} > div.propertyItem[item="0"] a#deleteIcon`)
     const confirmDeleteSel = 'div#deleteModal div.modal-body > button[ng-click="confirm();"]'
     await page.waitForSelector(confirmDeleteSel, {visible: true})
     await expect(page).toClick(confirmDeleteSel)
 
-    await expect_regex_not_in_sel_textContent(deleteTargetSel, 'Barcode')
+    await pupExpect.expectSelTextContentNotToMatch(deleteTargetSel, 'Barcode')
   })
 
   it.todo('change property definitions using the Change Property modal')
@@ -170,8 +171,8 @@ it('imports a v0.0.9 profile from a json file', async () => {
   const profilePath = path.join(__dirname, "..", "__fixtures__", 'foo_profile_sinopia_v0.0.9.json')
   await expect(page).toUploadFile('input[type="file"]', profilePath)
   await page.waitForSelector('span[popover-title="Profile ID: sinopia:profile:bf2:Foo"]', {visible: true})
-  await expect_regex_in_sel_textContent('span[popover-title="Profile ID: sinopia:profile:bf2:Foo"]', 'BIBFRAME 2.0 Foo')
-  await expect_regex_in_sel_textContent('span[popover-title="Resource ID: sinopia:resourceTemplate:bf2:Foo"]', 'Foo Associated with a Work')
+  await pupExpect.expectSelTextContentToMatch('span[popover-title="Profile ID: sinopia:profile:bf2:Foo"]', 'BIBFRAME 2.0 Foo')
+  await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: sinopia:resourceTemplate:bf2:Foo"]', 'Foo Associated with a Work')
 })
 
 it('imports a v0.1.0 profile from a json file', async () => {
@@ -181,8 +182,8 @@ it('imports a v0.1.0 profile from a json file', async () => {
   const profilePath = path.join(__dirname, "..", "__fixtures__", 'place_profile_sinopia_v0.1.0.json')
   await expect(page).toUploadFile('input[type="file"]', profilePath)
   await page.waitForSelector('span[popover-title="Profile ID: sinopia:profile:bf2:Place"]', {visible: true})
-  await expect_regex_in_sel_textContent('span[popover-title="Profile ID: sinopia:profile:bf2:Place"]', 'BIBFRAME 2.0 Place')
-  await expect_regex_in_sel_textContent('span[popover-title="Resource ID: sinopia:resourceTemplate:bf2:Place"]', 'Place Associated with a Work')
+  await pupExpect.expectSelTextContentToMatch('span[popover-title="Profile ID: sinopia:profile:bf2:Place"]', 'BIBFRAME 2.0 Place')
+  await pupExpect.expectSelTextContentToMatch('span[popover-title="Resource ID: sinopia:resourceTemplate:bf2:Place"]', 'Place Associated with a Work')
 })
 
 it('imports propertyURI value with # char cleanly', async () => {
@@ -197,26 +198,6 @@ it('imports propertyURI value with # char cleanly', async () => {
 
   // NOTE: this propertyURI has #
   const ptemplateSpanSel = 'span[popover-title="Property URI: http://www.w3.org/2000/01/rdf-schema#label"]'
-  await expect_sel_to_exist(ptemplateSpanSel)
+  await pupExpect.expectSelToExist(ptemplateSpanSel)
   // shameless green:  could not figure out a way to select the value in the actual input element
 })
-
-async function expect_regex_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toMatch(value)
-}
-async function expect_regex_not_in_sel_textContent(sel, value) {
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).not.toMatch(value)
-}
-async function expect_value_in_sel_input(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.value)
-  return expect(sel_text).toBe(value)
-}
-async function expect_sel_to_exist(sel) {
-  await page.waitForSelector(sel)
-  const sel_text = !!(await page.$(sel))
-  return expect(sel_text).toEqual(true)
-}

--- a/source/__tests__/integration/jestPuppeteerHelper.js
+++ b/source/__tests__/integration/jestPuppeteerHelper.js
@@ -1,0 +1,55 @@
+async function expectSelTextContentToMatch(sel, expected) {
+  await page.waitForSelector(sel)
+  const textContent = await page.$eval(sel, e => e.textContent)
+  return expect(textContent).toMatch(expected)
+}
+async function expectSelTextContentNotToMatch(sel, expected) {
+  const textContent = await page.$eval(sel, e => e.textContent)
+  return expect(textContent).not.toMatch(expected)
+}
+async function expectSelTextContentTrimmedToMatch(sel, expected) {
+  await page.waitForSelector(sel)
+  const textContent = await page.$eval(sel, e => e.textContent)
+  return expect(textContent.trim()).toMatch(expected)
+}
+async function expectSelValueToBe(sel, expected) {
+  await page.waitForSelector(sel)
+  const value = await page.$eval(sel, e => e.value)
+  return expect(value).toBe(expected)
+}
+async function expectSelTextContentToBe(sel, expected) {
+  await page.waitForSelector(sel)
+  const textContent = await page.$eval(sel, e => e.textContent)
+  return expect(textContent).toBe(expected)
+}
+async function expectSelTextContentNotToBe(sel, value) {
+  await page.waitForSelector(sel)
+  const textContent = await page.$eval(sel, e => e.textContent)
+  return expect(textContent.trim()).not.toBe(value)
+}
+async function expectSelTextContentTrimmedToBe(sel, expected) {
+  await page.waitForSelector(sel)
+  const textContent = await page.$eval(sel, e => e.textContent)
+  return expect(textContent.trim()).toBe(expected)
+}
+async function expectSelToExist(sel) {
+  await page.waitForSelector(sel)
+  const selector = !!(await page.$(sel))
+  return expect(selector).toEqual(true)
+}
+async function expectSelNotToExist(sel) {
+  const selector = !!(await page.$(sel))
+  return expect(selector).toEqual(false)
+}
+
+module.exports = {
+  expectSelTextContentToMatch,
+  expectSelTextContentNotToMatch,
+  expectSelTextContentTrimmedToMatch,
+  expectSelValueToBe,
+  expectSelTextContentToBe,
+  expectSelTextContentNotToBe,
+  expectSelTextContentTrimmedToBe,
+  expectSelToExist,
+  expectSelNotToExist
+}

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -215,18 +215,21 @@ describe('Adding, editing and removing a new Profile', () => {
 })
 
 async function expect_regex_in_sel_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toMatch(value)
+  return expect(sel_text).toMatch(value)
 }
 async function expect_sel_not_to_exist(sel) {
   const sel_text = !!(await page.$(sel))
-  expect(sel_text).toEqual(false)
+  return expect(sel_text).toEqual(false)
 }
 async function expect_value_in_selector_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
   return expect(sel_text.trim()).toBe(value)
 }
 async function expect_value_not_in_selector_textContent(sel, value) {
+  await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
   return expect(sel_text.trim()).not.toBe(value)
 }

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Adding, editing and removing a new Profile', () => {
   const sourceInputSel = '#profile input[name="source"]'
@@ -29,41 +30,41 @@ describe('Adding, editing and removing a new Profile', () => {
     describe('Required fields are indicated with asterisk', () => {
       it('ID', async () => {
         expect.assertions(1)
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="id"]`, "ID*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="id"]`, "ID*")
       })
       it('Description', async () => {
         expect.assertions(1)
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="description"]`, "Description*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="description"]`, "Description*")
       })
       it('Author', async () => {
         expect.assertions(1)
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="author"]`, "Author*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="author"]`, "Author*")
       })
       it('Title', async () => {
         expect.assertions(1)
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="title"]`, "Title*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="title"]`, "Title*")
       })
     })
     it('Date has no asterisk b/c it may be filled in automagically', async () => {
       expect.assertions(2)
-      await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="date"]`, "Date*")
-      await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="date"]`, "Date")
+      await pupExpect.expectSelTextContentNotToMatch(`${profile_fields_table_sel} label[for="date"]`, "Date*")
+      await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="date"]`, "Date")
     })
     describe('Non-required fields have no asterisk', () => {
       it('Remark', async () => {
         expect.assertions(2)
-        await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="remark"]`, "Remark*")
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="remark"]`, "Remark")
+        await pupExpect.expectSelTextContentNotToMatch(`${profile_fields_table_sel} label[for="remark"]`, "Remark*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="remark"]`, "Remark")
       })
       it('Adherence', async () => {
         expect.assertions(2)
-        await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="adherence"]`, "Adherence*")
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="adherence"]`, "Adherence")
+        await pupExpect.expectSelTextContentNotToMatch(`${profile_fields_table_sel} label[for="adherence"]`, "Adherence*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="adherence"]`, "Adherence")
       })
       it('Source', async () => {
         expect.assertions(2)
-        await expect_value_not_in_selector_textContent(`${profile_fields_table_sel} label[for="source"]`, "Source*")
-        await expect_value_in_selector_textContent(`${profile_fields_table_sel} label[for="source"]`, "Source")
+        await pupExpect.expectSelTextContentNotToMatch(`${profile_fields_table_sel} label[for="source"]`, "Source*")
+        await pupExpect.expectSelTextContentTrimmedToBe(`${profile_fields_table_sel} label[for="source"]`, "Source")
       })
     })
     describe('Adherence rules/standards that profile confirms with', () => {
@@ -71,7 +72,7 @@ describe('Adding, editing and removing a new Profile', () => {
 
       it('adherence input label and field', async () => {
         expect.assertions(2)
-        await expect_value_in_selector_textContent('#profile label[for="adherence"]', 'Adherence')
+        await pupExpect.expectSelTextContentTrimmedToBe('#profile label[for="adherence"]', 'Adherence')
         const field = await page.$eval(adherence_input_sel, e => e.getAttribute('name'))
         await expect(field).toBe('adherence')
       })
@@ -85,7 +86,7 @@ describe('Adding, editing and removing a new Profile', () => {
     describe('Source url', () => {
       it('source input label and field', async () => {
         expect.assertions(2)
-        await expect_value_in_selector_textContent('#profile label[for="source"]', 'Source')
+        await pupExpect.expectSelTextContentTrimmedToBe('#profile label[for="source"]', 'Source')
         const input_name = await page.$eval(sourceInputSel, e => e.getAttribute('name'))
         await expect(input_name).toBe('source')
       })
@@ -176,7 +177,7 @@ describe('Adding, editing and removing a new Profile', () => {
       const resourceSelectorSel = `${resourceChooseModalSel} > select#resourcePick`
       await expect(page).toSelect(resourceSelectorSel, 'Role')
 
-      await expect_regex_in_sel_textContent('span[popover="URI: http://id.loc.gov/ontologies/bibframe/Role"]', 'Role')
+      await pupExpect.expectSelTextContentToMatch('span[popover="URI: http://id.loc.gov/ontologies/bibframe/Role"]', 'Role')
     })
 
     it('removing resource template removes its span and input fields', async () => {
@@ -184,7 +185,7 @@ describe('Adding, editing and removing a new Profile', () => {
 
       const deleteTargetSel = 'span[popover="URI: http://id.loc.gov/ontologies/bibframe/Role"]'
       await page.waitForSelector(deleteTargetSel)
-      await expect_regex_in_sel_textContent(deleteTargetSel, 'Role')
+      await pupExpect.expectSelTextContentToMatch(deleteTargetSel, 'Role')
 
       const deleteRoleSel = 'div[name="resourceForm"] div#resource_0 #deleteButton'
       await page.waitForSelector(deleteRoleSel, {visible: true})
@@ -195,7 +196,7 @@ describe('Adding, editing and removing a new Profile', () => {
       await page.waitForSelector(modalConfirmDeleteSel, {visible: true})
       await expect(page).toClick(modalConfirmDeleteSel)
 
-      await expect_sel_not_to_exist(deleteTargetSel)
+      await pupExpect.expectSelNotToExist(deleteTargetSel)
     })
 
     it('alerts with error if non-uri profile source is entered and user switches focus', async () => {
@@ -205,7 +206,7 @@ describe('Adding, editing and removing a new Profile', () => {
       await expect(page).toClick('#profile input[name="description"]')
       const alertBoxSel = '#alertBox > div > div > div.modal-header > h3'
       await page.waitForSelector(alertBoxSel, {visible: true})
-      await expect_value_in_selector_textContent(alertBoxSel, 'Error!')
+      await pupExpect.expectSelTextContentTrimmedToBe(alertBoxSel, 'Error!')
       await page.waitForSelector('#alertClose', {visible: true})
       await page.click('#alertClose')
       const invalid_url_class = await page.$(sourceInputSel, e => e.getAttribute('ng-invalid-url'))
@@ -213,23 +214,3 @@ describe('Adding, editing and removing a new Profile', () => {
     })
   })
 })
-
-async function expect_regex_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toMatch(value)
-}
-async function expect_sel_not_to_exist(sel) {
-  const sel_text = !!(await page.$(sel))
-  return expect(sel_text).toEqual(false)
-}
-async function expect_value_in_selector_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text.trim()).toBe(value)
-}
-async function expect_value_not_in_selector_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text.trim()).not.toBe(value)
-}

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -10,6 +10,7 @@ describe('Adding, editing and removing a new Profile', () => {
 
   it('displays a new profile span', async () => {
     expect.assertions(1)
+    await page.waitForSelector('span[id="profileBanner"] > span')
     const span = await page.$eval('span[id="profileBanner"] > span', e => e.getAttribute('popover-title'))
     await expect(span).toMatch(/Profile ID: Undefined/)
   })

--- a/source/__tests__/integration/profile-create.test.js
+++ b/source/__tests__/integration/profile-create.test.js
@@ -31,10 +31,10 @@ async function expect_regex_in_selector_textContent(sel, regex) {
   await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
   const strippedTextContent = sel_text.replace(/\n+/g,' ').trim()
-  expect(strippedTextContent).toMatch(regex)
+  return expect(strippedTextContent).toMatch(regex)
 }
 async function expect_value_in_selector_textContent(sel, value) {
   await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }

--- a/source/__tests__/integration/profile-create.test.js
+++ b/source/__tests__/integration/profile-create.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Sinopia Profile Editor Create Page', () => {
   beforeAll(async () => {
@@ -7,34 +8,22 @@ describe('Sinopia Profile Editor Create Page', () => {
 
   it('text on page', async () => {
     expect.assertions(1)
-    await expect_regex_in_selector_textContent('h3.portlet-title', /Create a new Profile\s*\*Required Fields$/)
+    await pupExpect.expectSelTextContentToMatch('h3.portlet-title', /Create a new Profile\s*\*Required Fields$/m)
   })
   it('profile metadata span', async() => {
     expect.assertions(1)
-    await expect_regex_in_selector_textContent('h4.profile-header > span#profileBanner.accordion-toggle > span.ng-scope', 'Profile')
+    await pupExpect.expectSelTextContentToMatch('h4.profile-header > span#profileBanner.accordion-toggle > span.ng-scope', 'Profile')
   })
 
   it('header links', async () => {
     expect.assertions(2)
-    await expect_value_in_selector_textContent('div.sinopia-headerlinks > a:nth-child(1)', 'Linked Data Editor')
-    await expect_value_in_selector_textContent('div.sinopia-headerlinks > a:nth-child(2)', 'Help and Resources')
+    await pupExpect.expectSelTextContentToBe('div.sinopia-headerlinks > a:nth-child(1)', 'Linked Data Editor')
+    await pupExpect.expectSelTextContentToBe('div.sinopia-headerlinks > a:nth-child(2)', 'Help and Resources')
   })
 
   it('footer', async () => {
     expect.assertions(2)
     await expect(page).toMatch('funded by the Andrew W. Mellon Foundation')
-    await expect_value_in_selector_textContent('div.sinopia-footer > a:nth-child(2)', 'Linked Data for Production 2 (LD4P2)')
+    await pupExpect.expectSelTextContentToBe('div.sinopia-footer > a:nth-child(2)', 'Linked Data for Production 2 (LD4P2)')
   })
 })
-
-async function expect_regex_in_selector_textContent(sel, regex) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  const strippedTextContent = sel_text.replace(/\n+/g,' ').trim()
-  return expect(strippedTextContent).toMatch(regex)
-}
-async function expect_value_in_selector_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toBe(value)
-}

--- a/source/__tests__/integration/property-types.test.js
+++ b/source/__tests__/integration/property-types.test.js
@@ -26,5 +26,5 @@ describe('Type of Property in Resource in Profile', () => {
 async function expect_value_in_sel_textContent(sel, value) {
   await page.waitForSelector(sel)
   const sel_text = await page.$eval(sel, e => e.textContent)
-  expect(sel_text).toBe(value)
+  return expect(sel_text).toBe(value)
 }

--- a/source/__tests__/integration/property-types.test.js
+++ b/source/__tests__/integration/property-types.test.js
@@ -1,4 +1,5 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
+const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Type of Property in Resource in Profile', () => {
   beforeEach(async () => {
@@ -13,18 +14,12 @@ describe('Type of Property in Resource in Profile', () => {
   it('dropdown is correctly populated', async () => {
     expect.assertions(3)
     const propTypeSel = 'select[name="type"][ng-model="propertyTemplate.type"]'
-    await expect_value_in_sel_textContent(`${propTypeSel} > option:nth-child(1)`, 'literal')
-    await expect_value_in_sel_textContent(`${propTypeSel} > option:nth-child(2)`, 'resource')
-    await expect_value_in_sel_textContent(`${propTypeSel} > option:nth-child(3)`, 'lookup')
+    await pupExpect.expectSelTextContentToBe(`${propTypeSel} > option:nth-child(1)`, 'literal')
+    await pupExpect.expectSelTextContentToBe(`${propTypeSel} > option:nth-child(2)`, 'resource')
+    await pupExpect.expectSelTextContentToBe(`${propTypeSel} > option:nth-child(3)`, 'lookup')
   })
 
   // it('can select a type in dropdown', () => {
   //   // TODO: write this test
   // })
 })
-
-async function expect_value_in_sel_textContent(sel, value) {
-  await page.waitForSelector(sel)
-  const sel_text = await page.$eval(sel, e => e.textContent)
-  return expect(sel_text).toBe(value)
-}


### PR DESCRIPTION
This is a follow-on to PR #213.  It addresses some comments from @mjgiarlo and @jmartin-sul, and attempts to make the build more robust.

I still experience failures locally and on circleci;  I believe the percentage of passing builds is higher with these changes.

I was also able to find an easy way to reduce the number of eslint errors by adding "jquery" to the env section.

This is a partial fix for #215.