### PR TITLE
 propertyTemplate form: text box input for ResourceTemplate ID, not selector

### DIFF
--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -45,8 +45,8 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
     await pupExpect.expectSelValueToBe('input[popover-title="Property Label"]', 'Barcode')
     await pupExpect.expectSelValueToBe('select[popover-title="Mandatory"]', '0')
     await pupExpect.expectSelValueToBe('select[popover-title="Repeatable"]', '1')
-    const template_select_sel = 'div#template > div[item="0"] select[popover-title="Value Template Reference"]'
-    await expect(page).toMatchElement(template_select_sel)
+    const valueConstraintSel = 'div#template > div[item="0"] input[popover-title="ID of Resource Template to embed"]'
+    await expect(page).toMatchElement(valueConstraintSel)
   })
 
   describe('property template fields', () => {
@@ -75,36 +75,19 @@ describe('imports and edits a v0.0.2 profile from a json file', () => {
     //TODO: test selecting a Value Data type modal view and value selection
     it.todo('add Value Data Type definitions using the Select Data Type modal helper')
 
-    it('add resource template id from selector in "Templates" section', async () => {
-      // NOTE:  Not sure it's working properly in the app.
-      //   browser shows text selected, but inspected element html does NOT show additional changes to
-      //   the selected element (like, I picked 1, then I picked 2).
-
-      expect.assertions(4)
+    it('add resource template id in "Templates" section', async () => {
+      expect.assertions(3)
       const addTemplateSel = `${lastResTempPropTempSel} #valueConstraints div#template > a#addTemplate`
       await expect(page).toClick(addTemplateSel)
 
-      const resTemplateRefSel = `${lastResTempPropTempSel} #valueConstraints div#template select[popover-title="Value Template Reference"]`
-      await page.waitForSelector(resTemplateRefSel)
-      await pupExpect.expectSelTextContentToMatch(resTemplateRefSel, '')
-      await expect(page).toMatchElement(`${resTemplateRefSel} > option[selected="selected"][value="?"]`)
-
-      // FIXME:  the selector should be populated with ids of resource templates from the server.  See #212
+      const valTempRefTemplatesSel = 'div.panel[name="propertyForm"] #template.propertyItems'
+      const valTempRefDivSel = `${valTempRefTemplatesSel} > div.listItems[html="html/template.html"] > div > div`
+      const valTempRefInputSel = `${valTempRefDivSel} > input[id^="templateInput_"][type="text"]`
       const resTemplateId = 'profile:bf2:35mmFeatureFilm:Color'
-      // NOTE: This code technique can't seem to select the text
-      // await expect(page).toSelect(resTemplateRefSel, resTemplateId) // this didn't work;  dunno why
-      // NOTE: not positive this code selects the value
-      await page.waitForSelector(resTemplateRefSel)
-      await page.select(resTemplateRefSel, resTemplateId)
+      await expect(page).toFill(valTempRefInputSel, resTemplateId)
 
-      // NOTE: could not get any of these to work
-      // await expect(page).toMatchElement(`${resTemplateRefSel} > option[selected="selected"][value="${resTemplateId}"]`)
-      // await expect(page).toMatchElement(`${resTemplateRefSel} > option[selected="selected"][value*="Color"]`)
-      // await expect(page).toMatchElement(`${resTemplateRefSel} > option[selected="selected"][value^="profile:bf2"]`)
-      // await pupExpect.expectSelTextContentToMatch(resourceTemplateRefSel, "profile:bf2:35mmFeatureFilm:Color")
-
-      // NOTE: this is a shameless green way to hopefully show that a value has been selected
-      await expect(page).toMatchElement(`${resTemplateRefSel}.ng-dirty`)
+      // NOTE: this is a shameless green way to show that a value has been entered
+      await expect(page).toMatchElement(`${valTempRefInputSel}.ng-dirty`)
     })
 
     it('"Values" Add Value allows URI selection', async() => {

--- a/source/__tests__/integration/property-template-requirements.test.js
+++ b/source/__tests__/integration/property-template-requirements.test.js
@@ -12,61 +12,60 @@ describe('PropertyTemplate requirements', () => {
   })
 
   describe('adding a property template', () => {
-    const propTemplateSelectSelector = 'select#templateSelect_1_0'
     const ptFieldsTableSel = 'div.panel[name="propertyForm"] table'
 
     beforeAll(async () => {
       await page.waitForSelector('span[href="#property_1"]')
       await page.waitForSelector('a#addTemplate')
       await page.click('a#addTemplate')
-      return await page.waitForSelector(propTemplateSelectSelector)
+      return await page.waitForSelector(ptFieldsTableSel)
     })
 
-    it('clicking "Add Property Template" appends a property template section to the form', async () => {
+    test('clicking "Add Property Template" appends a property template section to the form', async () => {
       expect.assertions(1)
       await page.waitForSelector(ptFieldsTableSel)
       await expect(page).toMatchElement('i.fa-exclamation[id="error"]')
     })
 
     describe('property template form fields', () => {
-      it('has 3 input fields for the property template metadata', async () => {
+      test('has 3 input fields for the property template metadata', async () => {
         expect.assertions(1)
         const inputs = await page.$eval(ptFieldsTableSel, e => e.getElementsByTagName('input').length)
         expect(inputs).toBe(3)
       })
-      it('has 3 select fields for the property template metadata', async () => {
+      test('has 3 select fields for the property template metadata', async () => {
         expect.assertions(1)
         const selects = await page.$eval(ptFieldsTableSel, e => e.getElementsByTagName('select').length)
         expect(selects).toBe(3)
       })
 
       describe('Required fields are indicated with asterisk', () => {
-        it('Property URI', async () => {
+        test('Property URI', async () => {
           expect.assertions(1)
           await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="propertyURI"]`, "Property URI*")
         })
-        it('Property Label', async () => {
+        test('Property Label', async () => {
           expect.assertions(1)
           await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="propertyLabel"]`, "Property Label*")
         })
-        it('Type', async () => {
+        test('Type', async () => {
           expect.assertions(1)
           await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="type"]`, "Type*")
         })
       })
 
       describe('Non-required fields have no asterisk', () => {
-        it('Remark', async () => {
+        test('Remark', async () => {
           expect.assertions(2)
           await pupExpect.expectSelTextContentNotToBe(`${ptFieldsTableSel} label[for="remark"]`, "Guiding statement for the use of this property*")
           await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="remark"]`, "Guiding statement for the use of this property")
         })
-        it('Mandatory', async () => {
+        test('Mandatory', async () => {
           expect.assertions(2)
           await pupExpect.expectSelTextContentNotToBe(`${ptFieldsTableSel} label[for="mandatory"]`, "Mandatory*")
           await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="mandatory"]`, "Mandatory")
         })
-        it('Repeatable', async () => {
+        test('Repeatable', async () => {
           expect.assertions(2)
           await pupExpect.expectSelTextContentNotToBe(`${ptFieldsTableSel} label[for="repeatable"]`, "Repeatable*")
           await pupExpect.expectSelTextContentToBe(`${ptFieldsTableSel} label[for="repeatable"]`, "Repeatable")
@@ -78,21 +77,21 @@ describe('PropertyTemplate requirements', () => {
       const vcFieldsTableSel = 'div[ng-controller="ValueConstraintController"]'
 
       describe('Value Constraint', () => {
-        it('header', async () => {
+        test('header', async () => {
           expect.assertions(1)
           await pupExpect.expectSelTextContentToBe(`${vcFieldsTableSel} > #constraintHeader`, "Value Constraint")
         })
-        it('has no input fields', async () => {
+        test('has no input fields', async () => {
           expect.assertions(1)
           const inputs = await page.$eval(`${vcFieldsTableSel} > table`, e => e.getElementsByTagName('input').length)
           expect(inputs).toBe(0)
         });
-        it('has no select fields', async () => {
+        test('has no select fields', async () => {
           expect.assertions(1)
           const selects = await page.$eval(`${vcFieldsTableSel} > table`, e => e.getElementsByTagName('select').length)
           expect(selects).toBe(0)
         })
-        it('has Add Default Link', async () => {
+        test('has Add Default Link', async () => {
           expect.assertions(1)
           await pupExpect.expectSelTextContentTrimmedToMatch(`${vcFieldsTableSel} > a#addDefault`, "Add Default")
         })
@@ -101,43 +100,57 @@ describe('PropertyTemplate requirements', () => {
       describe('Value Data Type', () => {
         const vdtTableSel = `${vcFieldsTableSel} div[ng-controller="ValueDataTypeController"]`
 
-        it('header', async () => {
+        test('header', async () => {
           expect.assertions(1)
           await expect(page).toMatch('Value Data Type')
         })
-        it('has one input field', async () => {
+        test('has one input field', async () => {
           expect.assertions(1)
           const inputs = await page.$eval(vdtTableSel, e => e.getElementsByTagName('input').length)
           expect(inputs).toBe(1)
         })
-        it('has URI field', async () => {
+        test('has URI field', async () => {
           expect.assertions(1)
           await pupExpect.expectSelTextContentToBe(`${vdtTableSel} label[for="dataTypeURI"]`, "URI")
         })
       })
 
-      describe('Templates', () => {
-        it('dropdown populated with resource template ids (via profiles from versoSpoof)', async () => {
+      describe('Templates (ValueTemplateRefs)', () => {
+        const valTempRefTemplatesSel = 'div.panel[name="propertyForm"] #template.propertyItems'
+        const valTempRefDivSel = `${valTempRefTemplatesSel} > div.listItems[html="html/template.html"] > div > div`
+        const valTempRefInputSel = `${valTempRefDivSel} > input[id^="templateInput_"]`
+
+        test('heading is "Templates"', async() => {
           expect.assertions(1)
-          await page.waitForSelector(propTemplateSelectSelector)
-          const profile_count = await page.$eval(propTemplateSelectSelector, e => e.length)
-          expect(profile_count).toBe(242)
+          await pupExpect.expectSelTextContentToBe(`${valTempRefTemplatesSel} > h5`, "Templates")
         })
-        it('dropdown allows selection of a resource template id', async () => {
-          expect.assertions(4)
-          await page.waitForSelector(propTemplateSelectSelector)
-          // NOTE: the html always shows the first option selected, though the browser
-          //  shows the right thing.  So here we cheat and use indirect checking of attributes
-          //  to show a template can be selected
-          await expect(page).toMatchElement(`${propTemplateSelectSelector}.ng-pristine`)
-          await expect(page).toMatchElement(`${propTemplateSelectSelector} > option[selected="selected"][value="?"]`)
-          await page.select(propTemplateSelectSelector, 'sinopia:resourceTemplate:bf2:Form')
-          await expect(page).toMatchElement(`${propTemplateSelectSelector}.ng-dirty`)
-          await expect(page).toMatchElement(`${propTemplateSelectSelector} > option[selected="selected"][value^="sinopia:resourceTemplate:bf2"]`)
+
+        test('label of Template', async () => {
+          expect.assertions(1)
+          await pupExpect.expectSelTextContentToBe(`${valTempRefDivSel} > label[for="template"]`, "Template")
         })
+
+        test('input field is text box', async () => {
+          expect.assertions(1)
+          await expect(page).toMatchElement(`${valTempRefInputSel}[type="text"]`)
+        })
+
+        test('popover-title', async () => {
+          expect.assertions(1)
+          await expect(page).toMatchElement(`${valTempRefInputSel}[popover-title="ID of Resource Template to embed"]`)
+        })
+        test('popover', async () => {
+          expect.assertions(1)
+          await expect(page).toMatchElement(`${valTempRefInputSel}[popover="For use with type = resource. Enter the ID of the Resource Template that will be the object of this property."]`)
+        })
+
+        test.todo('on import - ensure existing valueTemplateRef shows up in UI')
+        test.todo('on import - ensure multiple existing valueTemplateRef all show up in UI')
+        test.todo('on export - ensure correct value is in rt in correct way')
+        test.todo('on export - ensure multiple values can be put in rt')
       })
 
-      it('Values - has Add Value link', async () => {
+      test('Values - has Add Value link', async () => {
         expect.assertions(1)
         await pupExpect.expectSelTextContentTrimmedToMatch(`${vcFieldsTableSel} > div#value > a#adValue`, "Add Value")
       })
@@ -145,7 +158,7 @@ describe('PropertyTemplate requirements', () => {
   })
 
   describe('property header appearence', () => {
-    it('font-awesome icon class is present', async () => {
+    test('font-awesome icon class is present', async () => {
       expect.assertions(1)
       await expect(page).toMatchElement(`.fa-caret-right`)
     })
@@ -161,7 +174,7 @@ describe('property URI and Label are required', () => {
     return await page.$eval(profileFormSel, e => e.reset())
   })
 
-  it('error if exported without property URI', async () => {
+  test('error if exported without property URI', async () => {
     expect.assertions(3)
     await page.waitForSelector(profileFormSel)
     await expect(page).toFillForm(profileFormSel, {
@@ -183,7 +196,7 @@ describe('property URI and Label are required', () => {
     await pupExpect.expectSelTextContentToBe(alertBoxSel, 'Parts of the form are invalid')
   })
 
-  it('error if exported without property Label', async () => {
+  test('error if exported without property Label', async () => {
     expect.assertions(3)
     await page.waitForSelector(profileFormSel)
     await expect(page).toFillForm(profileFormSel, {
@@ -204,7 +217,7 @@ describe('property URI and Label are required', () => {
     await pupExpect.expectSelTextContentToBe(alertBoxSel, 'Parts of the form are invalid')
   })
 
-  it('error if exported with invalid property uri', async () => {
+  test('error if exported with invalid property uri', async () => {
     expect.assertions(4)
     await expect(page).toFillForm('form.sinopia-profile-form[name="profileForm"]', {
       // all the other required fields from profile and resource template
@@ -229,7 +242,7 @@ describe('property URI and Label are required', () => {
     await pupExpect.expectSelTextContentToBe(alertBoxSel, "Parts of the form are invalid")
   })
 
-  it('can be exported with valid property URI', async () => {
+  test('can be exported with valid property URI', async () => {
     expect.assertions(5)
 
     await expect(page).toFillForm(profileFormSel, {
@@ -264,7 +277,7 @@ describe('choose propertyTemplate from menu', () => {
     return await page.click('a#propertyChoose')
   })
 
-  it('selecting property populates property form', async () => {
+  test('selecting property populates property form', async () => {
     expect.assertions(3)
     await page.waitForSelector('select[name="chooseVocab"]')
     await expect(page).toSelect('select[name="chooseVocab"]', 'Bibframe 2.0')

--- a/source/html/template.html
+++ b/source/html/template.html
@@ -1,24 +1,24 @@
 <div id="{{item}}_{{parentId}}">
-    <div>
-        <label for="template">Template</label>
-        <!-- <input id="templateInput_{{item}}_{{parentId}}" type="text" name="template" list="templateList" ng-model="valueConstraint.valueTemplateRefs[parentId]" 
-                popover="A resource template identifier that defines the expected value."
-                popover-title="Value Template Reference" popover-trigger="mouseenter"
-                popover-placement="right"/> -->
-        <!-- <datalist id="templateList"> -->
-            <select id="templateSelect_{{item}}_{{parentId}}"
-                    ng-options="item for item in selectList track by item"
-                    ng-model="valueConstraint.valueTemplateRefs[parentId]"
-                    popover="A resource template identifier that defines the expected value."
-                    popover-title="Value Template Reference" popover-trigger="mouseenter"
-                    popover-placement="right">
-            </select>
-        <!-- </datalist> -->
-        <a href="#" onclick="event.returnValue = false; return false;" ng-click="verifyDelete(deleteTemplate)">
-            <i class="fa fa-trash-o"></i>
-        </a>
-        <div class="error" ng-show="profileForm.template.$dirty && profileForm.template.$invalid">
-           <small class="error">url is invalid</small>
-       </div>
+  <div>
+    <label for="template">Template</label>
+    <!-- <input id="templateInput_{{item}}_{{parentId}}" type="text" name="template" list="templateList" ng-model="valueConstraint.valueTemplateRefs[parentId]"
+            popover="A resource template identifier that defines the expected value."
+            popover-title="Value Template Reference" popover-trigger="mouseenter"
+            popover-placement="right"/> -->
+    <!-- <datalist id="templateList"> -->
+      <select id="templateSelect_{{item}}_{{parentId}}"
+              ng-options="item for item in selectList track by item"
+              ng-model="valueConstraint.valueTemplateRefs[parentId]"
+              popover="A resource template identifier that defines the expected value."
+              popover-title="Value Template Reference" popover-trigger="mouseenter"
+              popover-placement="right">
+      </select>
+    <!-- </datalist> -->
+    <a href="#" onclick="event.returnValue = false; return false;" ng-click="verifyDelete(deleteTemplate)">
+      <i class="fa fa-trash-o"></i>
+    </a>
+    <div class="error" ng-show="profileForm.template.$dirty && profileForm.template.$invalid">
+      <small class="error">url is invalid</small>
     </div>
+  </div>
 </div>

--- a/source/html/template.html
+++ b/source/html/template.html
@@ -1,18 +1,18 @@
 <div id="{{item}}_{{parentId}}">
   <div>
     <label for="template">Template</label>
-    <!-- <input id="templateInput_{{item}}_{{parentId}}" type="text" name="template" list="templateList" ng-model="valueConstraint.valueTemplateRefs[parentId]"
-            popover="A resource template identifier that defines the expected value."
-            popover-title="Value Template Reference" popover-trigger="mouseenter"
-            popover-placement="right"/> -->
+    <input id="templateInput_{{item}}_{{parentId}}" type="text" name="template" list="templateList" ng-model="valueConstraint.valueTemplateRefs[parentId]"
+            popover="For use with type = resource. Enter the ID of the Resource Template that will be the object of this property."
+            popover-title="ID of Resource Template to embed" popover-trigger="mouseenter"
+            popover-placement="right"/>
     <!-- <datalist id="templateList"> -->
-      <select id="templateSelect_{{item}}_{{parentId}}"
+      <!-- <select id="templateSelect_{{item}}_{{parentId}}"
               ng-options="item for item in selectList track by item"
               ng-model="valueConstraint.valueTemplateRefs[parentId]"
               popover="A resource template identifier that defines the expected value."
               popover-title="Value Template Reference" popover-trigger="mouseenter"
               popover-placement="right">
-      </select>
+      </select> -->
     <!-- </datalist> -->
     <a href="#" onclick="event.returnValue = false; return false;" ng-click="verifyDelete(deleteTemplate)">
       <i class="fa fa-trash-o"></i>


### PR DESCRIPTION
Also adjusted popover title and text per instructions in #212.

I will work on the 4 "todo" tests I added right away, but wanted to unblock M3.  I manually tested the "todo" tests and know it works.

Fixes #212