### PR TITLE
tests: if setup or tear down is async, no need for explicit return

### DIFF
--- a/source/__tests__/integration/edit-profile.test.js
+++ b/source/__tests__/integration/edit-profile.test.js
@@ -9,7 +9,7 @@ describe('edits an imported v0.0.2 profile', () => {
     await expect(page).toUploadFile('input[type="file"]', profilePath)
     const profileLoadedSel = 'div#profile-panel .panel-heading span[popover-title="Profile ID: profile:bf2:Item"]'
     await page.waitForSelector(profileLoadedSel, {visible: true})
-    return await expect(page).toClick(profileLoadedSel)
+    await expect(page).toClick(profileLoadedSel)
   })
 
   // FIXME: describe('edits imported profile' ... from import-profile tests should move here, but I had trouble
@@ -19,7 +19,7 @@ describe('edits an imported v0.0.2 profile', () => {
   describe('edit resource templates in profile', () => {
     beforeAll(async () => {
       await page.waitForSelector('a#addResource')
-      return await page.click('a#addResource')
+      await page.click('a#addResource')
     })
 
     test('add (Role) known resource template via Select Resource', async() => {

--- a/source/__tests__/integration/empty-profile-export.test.js
+++ b/source/__tests__/integration/empty-profile-export.test.js
@@ -3,7 +3,7 @@
 describe('Sinopia Profile Editor does not export an invalid Profile', () => {
 
   beforeAll(async () => {
-    return await page.goto('http://localhost:8000/#/profile/create/true')
+    await page.goto('http://localhost:8000/#/profile/create/true')
   })
 
   describe('invalid profile exported', () => {

--- a/source/__tests__/integration/export-profile.test.js
+++ b/source/__tests__/integration/export-profile.test.js
@@ -39,7 +39,7 @@ describe('Profiles Export', () => {
 
   describe('exports cleanly', () => {
     beforeAll(async () => {
-      return await page.goto('http://127.0.0.1:8000/#/profile/create/')
+      await page.goto('http://127.0.0.1:8000/#/profile/create/')
     })
 
     beforeEach(async () => {
@@ -67,7 +67,7 @@ describe('Profiles Export', () => {
     })
 
     afterEach(async() => {
-      return await page.reload('http://127.0.0.1:8000/#/profile/create/')
+      await page.reload('http://127.0.0.1:8000/#/profile/create/')
     })
 
     it.each`
@@ -99,7 +99,7 @@ describe('Profiles Export', () => {
     const rt009SchemaURL = 'https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json'
 
     afterEach(async() => {
-      return await page.reload('http://127.0.0.1:8000/#/profile/create/')
+      await page.reload('http://127.0.0.1:8000/#/profile/create/')
     })
 
     test('0.0.9 when profile created from scratch', async () => {

--- a/source/__tests__/integration/footer.test.js
+++ b/source/__tests__/integration/footer.test.js
@@ -8,7 +8,7 @@ describe('Sinopia Profile Editor Footer', () => {
   `('header titles and links', ({pageUrl}) => {
 
     beforeAll(async () => {
-      return await page.goto(pageUrl)
+      await page.goto(pageUrl)
     })
 
     test('funding statement', async () => {

--- a/source/__tests__/integration/header.test.js
+++ b/source/__tests__/integration/header.test.js
@@ -10,7 +10,7 @@ describe('Sinopia Profile Editor Header', () => {
   `('titles and links', ({pageUrl}) => {
 
     beforeAll(async () => {
-      return await page.goto(pageUrl)
+      await page.goto(pageUrl)
     })
 
     test('h2.sinopia-subtitle contains a link', async () => {

--- a/source/__tests__/integration/home-page.test.js
+++ b/source/__tests__/integration/home-page.test.js
@@ -4,7 +4,7 @@ const pupExpect = require('./jestPuppeteerHelper')
 describe('Sinopia Profile Editor Homepage', () => {
 
   beforeAll(async () => {
-    return await page.goto('http://127.0.0.1:8000')
+    await page.goto('http://127.0.0.1:8000')
   })
 
   it('redirects to profile/sinopia', async () => {

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -9,7 +9,7 @@ describe('imports valid profile without included schema url from json file', () 
     await expect(page).toUploadFile('input[type="file"]', profilePath)
     const profileLoadedSel = 'div#profile-panel .panel-heading span[popover-title="Profile ID: profile:bf2:Item"]'
     await page.waitForSelector(profileLoadedSel, {visible: true})
-    return await expect(page).toClick(profileLoadedSel)
+    await expect(page).toClick(profileLoadedSel)
   })
 
   test('profile attribute values', async () => {
@@ -68,7 +68,7 @@ describe('imports valid profile without included schema url from json file', () 
   describe('edits imported profile', () => {
     beforeAll(async () => {
       await expect(page).toClick('a#addResource')
-      return await expect(page).toClick('#resourceTemplates_0 > div:last-child a.propertyLink')
+      await expect(page).toClick('#resourceTemplates_0 > div:last-child a.propertyLink')
     })
 
     const lastResTempPropTempSel = '#resourceTemplates_0 > div:last-child div[name="propertyForm"]'
@@ -105,7 +105,7 @@ describe('imports valid profile without included schema url from json file', () 
     test('"Values" Add Value allows URI selection', async() => {
       expect.assertions(5)
       const addValSel = 'div#value > #adValue'
-      await page.waitForSelector(addValSel, {visible: true})
+      await page.waitForSelector(addValSel, {visible: true, timeout: 5000})
       await page.click(addValSel)
       const useValuesFromSel = 'div#value select[popover-title="Use Values From"]'
       await page.waitForSelector(useValuesFromSel, {visible: true})

--- a/source/__tests__/integration/import-profile.test.js
+++ b/source/__tests__/integration/import-profile.test.js
@@ -69,6 +69,8 @@ describe('imports valid profile without included schema url from json file', () 
     beforeAll(async () => {
       await expect(page).toClick('a#addResource')
       await expect(page).toClick('#resourceTemplates_0 > div:last-child a.propertyLink')
+      const addValSel = 'div#value > #adValue'
+      await page.waitForSelector(addValSel, {visible: true, timeout: 5000})
     })
 
     const lastResTempPropTempSel = '#resourceTemplates_0 > div:last-child div[name="propertyForm"]'
@@ -105,7 +107,6 @@ describe('imports valid profile without included schema url from json file', () 
     test('"Values" Add Value allows URI selection', async() => {
       expect.assertions(5)
       const addValSel = 'div#value > #adValue'
-      await page.waitForSelector(addValSel, {visible: true, timeout: 5000})
       await page.click(addValSel)
       const useValuesFromSel = 'div#value select[popover-title="Use Values From"]'
       await page.waitForSelector(useValuesFromSel, {visible: true})

--- a/source/__tests__/integration/new-profile.test.js
+++ b/source/__tests__/integration/new-profile.test.js
@@ -5,7 +5,7 @@ describe('Adding, editing and removing a new Profile', () => {
   const sourceInputSel = '#profile input[name="source"]'
 
   beforeAll(async () => {
-    return await page.goto('http://localhost:8000/#/profile/create/')
+    await page.goto('http://localhost:8000/#/profile/create/')
   })
 
   it('displays a new profile span', async () => {
@@ -19,7 +19,7 @@ describe('Adding, editing and removing a new Profile', () => {
     const profile_fields_table_sel = 'div[id="profile"] > div.panel-body > table'
 
     beforeAll(async () => {
-      return await page.waitForSelector(profile_fields_table_sel)
+      await page.waitForSelector(profile_fields_table_sel)
     })
 
     it('has eight input fields for the profile admin data', async () => {
@@ -110,7 +110,7 @@ describe('Adding, editing and removing a new Profile', () => {
     beforeAll(async () => {
       await page.waitForSelector('#addResource')
       await page.click('#addResource')
-      return await page.waitForSelector('div[name="resourceForm"]')
+      await page.waitForSelector('div[name="resourceForm"]')
     })
 
     it('displays a new resource template span', async () => {
@@ -147,7 +147,7 @@ describe('Adding, editing and removing a new Profile', () => {
       await page.waitForSelector('div[name="resourceForm"]')
       await page.waitForSelector('.propertyLink')
       await page.click('.propertyLink')
-      return await page.waitForSelector('div[name="propertyForm"]')
+      await page.waitForSelector('div[name="propertyForm"]')
     })
 
     it('has 6 top level attribute fields', async() => {

--- a/source/__tests__/integration/off-canvas-menu.test.js
+++ b/source/__tests__/integration/off-canvas-menu.test.js
@@ -11,7 +11,7 @@ describe('Off-canvas Help Menu', () => {
     await page.waitForSelector(helpLinkSel)
     await page.click(helpLinkSel)
     await page.waitFor(500, {waitUntil: 'networkidle0'}) // it gets content from sinopia github pages
-    return await page.waitForSelector(menuIdSel, {visible: true})
+    await page.waitForSelector(menuIdSel, {visible: true})
   })
 
   // Note:  Help and Resources link is tested in header.test

--- a/source/__tests__/integration/profile-create-page.test.js
+++ b/source/__tests__/integration/profile-create-page.test.js
@@ -3,7 +3,7 @@ const pupExpect = require('./jestPuppeteerHelper')
 
 describe('Sinopia Profile Editor Create Page', () => {
   beforeAll(async () => {
-    return await page.goto('http://127.0.0.1:8000/#/profile/create/')
+    await page.goto('http://127.0.0.1:8000/#/profile/create/')
   })
 
   it('text on page', async () => {

--- a/source/__tests__/integration/profile-metadata-requirements.test.js
+++ b/source/__tests__/integration/profile-metadata-requirements.test.js
@@ -4,12 +4,12 @@ const pupExpect = require('./jestPuppeteerHelper')
 describe('Validating the profile metadata', () => {
 
   beforeAll(async () => {
-    return await page.goto('http://localhost:8000/#/profile/create/')
+    await page.goto('http://localhost:8000/#/profile/create/')
   })
 
   describe('missing required profile metadata fields', () => {
     afterEach(async () => {
-      return await page.$eval('form[name="profileForm"]', e => e.reset())
+      await page.$eval('form[name="profileForm"]', e => e.reset())
     })
 
     it.each`

--- a/source/__tests__/integration/property-template-requirements.test.js
+++ b/source/__tests__/integration/property-template-requirements.test.js
@@ -8,7 +8,7 @@ describe('PropertyTemplate requirements', () => {
     await page.click('a#addResource')
     await page.waitForSelector('a.propertyLink')
     await page.click('a.propertyLink')
-    return await page.waitForSelector('span[href="#property_1"]')
+    await page.waitForSelector('span[href="#property_1"]')
   })
 
   describe('adding a property template', () => {
@@ -18,7 +18,7 @@ describe('PropertyTemplate requirements', () => {
       await page.waitForSelector('span[href="#property_1"]')
       await page.waitForSelector('a#addTemplate')
       await page.click('a#addTemplate')
-      return await page.waitForSelector(ptFieldsTableSel)
+      await page.waitForSelector(ptFieldsTableSel)
     })
 
     test('clicking "Add Property Template" appends a property template section to the form', async () => {
@@ -173,7 +173,7 @@ describe('property URI and Label are required', () => {
   const alertBoxSel = '#alertBox > div.modal-dialog > div.modal-content > div.modal-body > p#alert_text'
 
   afterEach(async () => {
-    return await page.$eval(profileFormSel, e => e.reset())
+    await page.$eval(profileFormSel, e => e.reset())
   })
 
   test('error if exported without property URI', async () => {
@@ -276,7 +276,7 @@ describe('choose propertyTemplate from menu', () => {
   beforeAll(async () => {
     await page.goto('http://127.0.0.1:8000/#/profile/create/')
     await page.waitForSelector('a#propertyChoose')
-    return await page.click('a#propertyChoose')
+    await page.click('a#propertyChoose')
   })
 
   test('selecting property populates property form', async () => {

--- a/source/__tests__/integration/property-types.test.js
+++ b/source/__tests__/integration/property-types.test.js
@@ -8,7 +8,7 @@ describe('Type of Property in Resource in Profile', () => {
     await page.click('a#addResource')
     await page.waitForSelector('a.propertyLink')
     await page.click('a.propertyLink')
-    return await page.waitForSelector('span[href="#property_1"]')
+    await page.waitForSelector('span[href="#property_1"]')
   })
 
   it('dropdown is correctly populated', async () => {

--- a/source/__tests__/integration/resource-template-requirements.test.js
+++ b/source/__tests__/integration/resource-template-requirements.test.js
@@ -7,7 +7,7 @@ describe('Create profile resource template requirements', () => {
     await page.goto('http://localhost:8000/#/profile/create/')
     await page.waitForSelector('a#addResource')
     await page.click('a#addResource')
-    return await page.waitForSelector('a.propertyLink')
+    await page.waitForSelector('a.propertyLink')
   })
 
   describe('resource template form fields', () => {
@@ -85,11 +85,11 @@ describe('Create profile resource template requirements', () => {
         await page.click('a#addResource')
         await page.waitForSelector('a.propertyLink')
         await page.click('a.propertyLink')
-        return await page.waitForSelector('span[href="#property_1"]')
+        await page.waitForSelector('span[href="#property_1"]')
       })
 
       afterEach(async() => {
-        return await page.$eval('form[name="profileForm"]', e => e.reset())
+        await page.$eval('form[name="profileForm"]', e => e.reset())
       })
 
       it('requires Resource ID', async () => {

--- a/source/__tests__/integration/select-resource-template-menu.test.js
+++ b/source/__tests__/integration/select-resource-template-menu.test.js
@@ -9,7 +9,7 @@ describe('Select Resource Template Menu', () => {
     await page.click('a#addResource')
     await page.waitForSelector('a#resourceChoose')
     await page.click('a#resourceChoose')
-    return await page.waitForSelector(modalSel)
+    await page.waitForSelector(modalSel)
   })
 
   it('modal title says Choose Resource Template', async () => {
@@ -24,7 +24,7 @@ describe('Select Resource Template Menu', () => {
     const selectVocabSel = `${modalBodySel} > div#select_box_holder > select[name="chooseVocab"]`
 
     beforeAll( async() => {
-      return await page.waitForSelector(selectVocabSel)
+      await page.waitForSelector(selectVocabSel)
     })
 
     it('populated with ontologies (via versoSpoof)', async () => {


### PR DESCRIPTION
This PR adapts our tests to have better syntax for async setup and teardown methods. 

from https://jestjs.io/docs/en/setup-teardown

> beforeEach and afterEach can handle asynchronous code in the same ways that tests can  handle asynchronous code - they can either take a done parameter or return a promise. For example, if [ promiseFromFunction() ] returned a promise that resolved when the database was initialized, we would want to return that promise:

```js
beforeEach(() => {
  return promiseFromFunction()
})
```

As @jmartin-sul points out in https://github.com/LD4P/sinopia_editor/issue/840 and also in [this PR comment](https://github.com/LD4P/sinopia_editor/pull/820#discussion_r297858708), an `async` method, by definition, returns a promise.  So this is also an appropriate way for a setup/teardown method to handle asynchronous code:

```js
beforeEach(async () => {
  await promiseFromFunction()
})
```

The benefit of the second approach is it also allows for multiple await statements, and makes the asynchronous code more obviously async:

```js
beforeEach(async () => {
  await promiseToReviewThisPR()
  await promiseToMergeThisPR()
  await promiseToFinishSinopiaWorkCycle()
})
```
